### PR TITLE
Configure reports to be stored in a shared directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Note that these are used to configure `DATABASE` in `configuration.py`.
         - localhost
         - 127.0.0.1
       MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+      REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
 
 This is a dictionary of settings used to template NetBox's `configuration.py`.
 See [Mandatory Settings] and [Optional Settings] from the NetBox documentation
@@ -110,9 +111,10 @@ The `SECRET_KEY` will then be read from this file on subsequent runs, unless you
 later do set this in your playbook. Note that you should define the `SECRET_KEY`
 if you are deploying multiple NetBox instances behind one load balancer.
 
-`MEDIA_ROOT`, while not mandatory in the NetBox documentation, is mandatory in
-this role. It should be set to a directory that is permanent and not lost on
-upgrade (the default, listed above, can be used without issue).
+`MEDIA_ROOT`/`REPORTS_ROOT`, while not mandatory in the NetBox documentation,
+is mandatory in this role in order to prevent missing files. It should be set to
+a directory that is permanent and not lost on upgrade (the default, listed
+above, can be used without issue).
 
     netbox_user: netbox
     netbox_group: netbox
@@ -195,6 +197,7 @@ socket to talk to the Postgres server with the default netbox database user.
           ALLOWED_HOSTS:
             - netbox.idolactiviti.es
           MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+          REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
         postgresql_users:
           - name: "{{ netbox_database_user }}"
             role_attr_flags: CREATEDB,NOSUPERUSER
@@ -217,6 +220,7 @@ installing NetBox on to authenticate with it over TCP:
           ALLOWED_HOSTS:
             - "{{ inventory_hostname }}"
           MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+          REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
         netbox_database_host: pg-netbox.idolactiviti.es
         netbox_database_port: 15432
         netbox_database: netbox_prod

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ netbox_config:
   #NAPALM_USERNAME:
   #NAPALM_PASSWORD:
   MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+  REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
 
 netbox_user: netbox
 netbox_group: netbox

--- a/examples/netbox_config.yml
+++ b/examples/netbox_config.yml
@@ -43,3 +43,4 @@ netbox_config:
   DATETIME_FORMAT: 'N j, Y g:i a'
   SHORT_DATETIME_FORMAT: 'Y-m-d H:i'
   MEDIA_ROOT: /srv/netbox_media
+  REPORTS_ROOT: /srv/netbox_reports

--- a/examples/playbook_single_host_deploy.yml
+++ b/examples/playbook_single_host_deploy.yml
@@ -12,6 +12,7 @@
       ALLOWED_HOSTS:
         - "{{ inventory_hostname }}"
       MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+      REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
     netbox_database_socket: "{{ postgresql_unix_socket_directories[0] }}"
     postgresql_users:
       - name: "{{ netbox_database_user }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -7,6 +7,7 @@
     - "{{ netbox_releases_path }}"
     - "{{ netbox_shared_path }}"
     - "{{ netbox_shared_path }}/media/image-attachments"
+    - "{{ netbox_shared_path }}/reports"
 
 - include: "install_via_{{ 'git' if netbox_git else 'stable' }}.yml"
 


### PR DESCRIPTION
Realised this directory was effectively being cleared out on every upgrade thanks to https://github.com/digitalocean/netbox/issues/1938.

If anyone using this role is using the reports feature, they'll need to copy all of their files into the shared directory after running the updated role:

    cd /srv/netbox/releases/netbox-$VERSION/netbox/reports
    mv * /srv/netbox/shared/reports/