### PR TITLE
NetBox 2.4 release preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+  - "2.7"
+  - "3.6"
 sudo: required
 dist: trusty
 cache:
@@ -13,7 +16,11 @@ addons:
 env:
 - ANSIBLE_GIT_VERSION='devel' # 2.6.x development branch
 - ANSIBLE_VERSION='<2.6.0' # 2.5.x
-- ANSIBLE_VERSION='<2.5.0' # 2.4.x
+matrix:
+  fast_finish: true
+  include:
+    - python: '2.7'
+      env: ANSIBLE_VERSION='<2.5.0' # 2.4.x
 install:
 - if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
   else pip install "ansible${ANSIBLE_VERSION}"; fi
@@ -29,11 +36,11 @@ before_script:
 - cd tests/
 script:
 - ansible-playbook -i inventory deploy.yml --syntax-check
-- ansible-playbook -i inventory deploy.yml
-- 'ANSIBLE_STDOUT_CALLBACK=debug unbuffer ansible-playbook -i inventory -vv
-  deploy.yml > idempotency.log 2>&1 || (e=$?; cat idempotency.log; exit $e)'
-- 'grep -A1 "PLAY RECAP" idempotency.log | grep -qP "changed=0 .*failed=0 .*" &&
-  (echo "Idempotence: PASS"; exit 0) || (echo "Idempotence: FAIL"; exit 1)'
+- ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i inventory deploy.yml
+- 'ANSIBLE_STDOUT_CALLBACK=debug unbuffer ansible-playbook -vvi inventory
+  deploy.yml > play.log || (e=$?; cat play.log; exit $e); printf "Idempotence: ";
+  grep -A1 "PLAY RECAP" play.log | grep -qP "changed=0 .*failed=0 .*"
+  && (echo "PASS"; exit 0) || (echo "FAIL"; cat play.log; exit 1)'
 - ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i inventory -v test.yml
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,10 @@ env:
 - ANSIBLE_GIT_VERSION='devel' # 2.6.x development branch
 - ANSIBLE_VERSION='<2.6.0' # 2.5.x
 - ANSIBLE_VERSION='<2.5.0' # 2.4.x
-- ANSIBLE_VERSION='<2.4.0' # 2.3.x
 install:
 - if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
-  elif [ "$ANSIBLE_VERSION" ]; then pip install "ansible${ANSIBLE_VERSION}";
-  else pip install ansible; fi
+  else pip install "ansible${ANSIBLE_VERSION}"; fi
 - ansible --version
-# The following is needed for default Ansible 2.3 installations
-- 'sudo mkdir -p /etc/ansible/roles && sudo chown $(whoami): /etc/ansible/roles'
 - ansible-galaxy install lae.travis-lxc
 - ansible-playbook tests/install.yml -i tests/inventory
 - git archive --format tar.gz HEAD > lae.netbox.tar.gz && ansible-galaxy install

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ lae.netbox
 Deploys and configures DigitalOcean's [NetBox].
 
 This role will deploy NetBox within its own virtualenv either by release tarball
-or via git using Python 3 (or 2 if you're so inclined) and uWSGI as the
-application server.
+or via git using uWSGI as the application server.
 
 Tested and supported against CentOS 7/Debian 8 and 9/Ubuntu 16.
 
@@ -136,10 +135,6 @@ is where a `git archive` using the ref `netbox_git_version` will be extracted to
 service/configuration files as the location NetBox is installed.
 `netbox_shared_path` is intended to store configuration files and other "shared"
 content, like logs.
-
-    netbox_python: 3
-
-If you wish to deploy using Python 2, set this to `2`.
 
     netbox_socket: "127.0.0.1:8000"
     netbox_protocol: http

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.3.3
+netbox_stable_version: 2.4.1
 netbox_stable_uri: "https://github.com/digitalocean/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,6 @@ netbox_git_deploy_path: "{{ netbox_releases_path }}/git-deploy"
 netbox_stable_path: "{{ netbox_releases_path }}/netbox-{{ netbox_stable_version }}"
 netbox_current_path: "{{ netbox_home }}/current"
 netbox_shared_path: "{{ netbox_home }}/shared"
-netbox_python: 3
 
 netbox_socket: "127.0.0.1:8000"
 netbox_protocol: http

--- a/examples/netbox_config.yml
+++ b/examples/netbox_config.yml
@@ -12,16 +12,21 @@ netbox_config:
       - Dale Gribble
       - dgribble@example.com
   # note that the array is nested above
-  BANNER_TOP: &BANNER_TOP 'Your banner text'
   BANNER_BOTTOM: *BANNER_TOP
   BANNER_LOGIN: ''
+  BANNER_TOP: &BANNER_TOP 'Your banner text'
   # you probably won't need this, but you can reference other variables like above
   BASE_PATH: netbox/
+  CHANGELOG_RETENTION: 90
   CORS_ORIGIN_ALLOW_ALL: false
+  #CORS_ORIGIN_REGEX_WHITELIST:
   CORS_ORIGIN_WHITELIST:
     - hostname.domain.example
+  DATE_FORMAT: N j, Y
+  DATETIME_FORMAT: 'N j, Y g:i a'
   DEBUG: yes
   # yes, no, false, true, False, True are all valid booleans in Ansible - they will be inserted correctly in configuration.py
+  ENFORCE_GLOBAL_UNIQUE: False
   EMAIL:
     SERVER: localhost
     PORT: 25
@@ -29,7 +34,6 @@ netbox_config:
     PASSWORD: password
     TIMEOUT: 10
     FROM_EMAIL: notifications@localhost
-  ENFORCE_GLOBAL_UNIQUE: False
   LOGGING:
     version: 1
     disable_existing_loggers: False
@@ -44,20 +48,25 @@ netbox_config:
   LOGIN_REQUIRED: yes
   MAINTENANCE_MODE: False
   MAX_PAGE_SIZE: 500
-  PAGINATE_COUNT: 100
-  PREFER_IPV4: False
+  MEDIA_ROOT: /srv/netbox_media
   NAPALM_USERNAME: netbox
   NAPALM_PASSWORD: NetBox42
   NAPALM_TIMEOUT: 30
   NAPALM_ARGS:
     keepalive: 60
-  TIME_ZONE: UTC
-  DATE_FORMAT: N j, Y
+  PAGINATE_COUNT: 100
+  PREFER_IPV4: False
+  REPORTS_ROOT: /srv/netbox_reports
+  REDIS:
+    HOST: localhost
+    PORT: 6379
+    PASSWORD: redisisfun
+    DATABASE: 0
+    DEFAULT_TIMEOUT: 300
   # quotes aren't necessary as you can see - but in my opinion quotes make this more readable
   SHORT_DATE_FORMAT: 'Y-m-d'
-  TIME_FORMAT: 'g:i a'
-  SHORT_TIME_FORMAT: 'H:i:s'
-  DATETIME_FORMAT: 'N j, Y g:i a'
   SHORT_DATETIME_FORMAT: 'Y-m-d H:i'
-  MEDIA_ROOT: /srv/netbox_media
-  REPORTS_ROOT: /srv/netbox_reports
+  SHORT_TIME_FORMAT: 'H:i:s'
+  TIME_FORMAT: 'g:i a'
+  TIME_ZONE: UTC
+  WEBHOOKS_ENABLED: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Musee Ullah
   description: Installs and configures NetBox, a DCIM suite, in a production setting.
   license: MIT
-  min_ansible_version: 2.1
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,15 +6,12 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
-        - yakkety
-        - zesty
-        - artful
     - name: Debian
       versions:
         - stretch
         - jessie
-        - sid
     - name: EL
       versions:
         - 7

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -29,7 +29,7 @@
   pip:
     requirements: "{{ netbox_current_path }}/requirements.txt"
     virtualenv: "{{ netbox_virtualenv_path }}"
-    virtualenv_python: "{{ netbox_python3_binary if (netbox_python == 3) else netbox_python2_binary }}"
+    virtualenv_python: "{{ netbox_python_binary }}"
   become: True
   become_user: "{{ netbox_user }}"
 

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -11,9 +11,9 @@
     - "{{ netbox_shared_path }}/media/image-attachments"
     - "{{ netbox_shared_path }}/reports"
 
-- include: "install_via_{{ 'git' if netbox_git else 'stable' }}.yml"
+- include_tasks: "install_via_{{ 'git' if netbox_git else 'stable' }}.yml"
 
-- include: generate_secret_key.yml
+- import_tasks: generate_secret_key.yml
   when:
     - netbox_config.SECRET_KEY is not defined
 

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -17,14 +17,6 @@
   when:
     - netbox_config.SECRET_KEY is not defined
 
-- name: Pin Django REST Framework dependency to under 3.7.0 for NetBox 2.1.5 and below
-  replace:
-    path: "{{ netbox_current_path }}/requirements.txt"
-    regexp: '^(djangorestframework>=\d+\.\d+(\.\d+)?)$'
-    replace: '\1,<3.7.0'
-  when:
-    - (netbox_stable and netbox_stable_version | version_compare('2.1.5', '<=')) or (netbox_git and __netbox_git_contains_issue_1563_fix.rc == 1)
-
 - name: Create NetBox virtualenv and install needed Python dependencies
   pip:
     requirements: "{{ netbox_current_path }}/requirements.txt"
@@ -89,17 +81,6 @@
     state: "{{ 'link' if netbox_ldap_enabled else 'absent' }}"
   notify:
     - reload netbox.service
-
-- name: Set MEDIA_ROOT to shared media directory (will be deprecated - if this is not skipped please update your NetBox)
-  lineinfile:
-    path: "{{ netbox_config_path }}/settings.py"
-    regexp: '^MEDIA_ROOT\s*='
-    line: 'MEDIA_ROOT = "{{ netbox_shared_path }}/media/"'
-    state: present
-  notify:
-    - reload netbox.service
-  when:
-    - (netbox_stable and netbox_stable_version | version_compare('2.1.4', '<')) or (netbox_git and __netbox_git_contains_media_root_change.rc == 1)
 
 - block:
   - name: Run database migrations for NetBox

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -32,6 +32,7 @@
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
     mode: 0640
+    validate: "{{ netbox_virtualenv_path }}/bin/python -c \"import py_compile,os; f=r'%s'; c='/tmp/' + os.path.basename(os.path.dirname(f)) + '-' + os.path.basename(f) + 'c'; py_compile.compile(f, c); os.remove(c)\""
   notify:
     - reload netbox.service
 
@@ -50,6 +51,7 @@
       owner: "{{ netbox_user }}"
       group: "{{ netbox_group }}"
       mode: 0640
+      validate: "{{ netbox_virtualenv_path }}/bin/python -c \"import py_compile,os; f=r'%s'; c='/tmp/' + os.path.basename(os.path.dirname(f)) + '-' + os.path.basename(f) + 'c'; py_compile.compile(f, c); os.remove(c)\""
     notify:
       - reload netbox.service
   when:

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -74,7 +74,7 @@
 
 - name: Symlink/Remove NetBox LDAP configuration file into/from the active NetBox release
   file:
-    src: "{{ netbox_shared_path }}/ldap_config.py"
+    src: "{{ netbox_shared_path + '/ldap_config.py' if netbox_ldap_enabled else omit }}"
     dest: "{{ netbox_config_path }}/ldap_config.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"

--- a/tasks/install_packages_apt.yml
+++ b/tasks/install_packages_apt.yml
@@ -6,10 +6,8 @@
     cache_valid_time: 3600
     update_cache: yes
   with_items:
-    - "{{ netbox_python3_packages if (netbox_python == 3) else netbox_python2_packages }}"
+    - "{{ netbox_python_packages }}"
     - "{{ netbox_packages }}"
     - "{{ netbox_ldap_packages if netbox_ldap_enabled else [] }}"
     - "{{ 'git' if netbox_git else [] }}"
-    - "{{ 'python-psycopg2' if (ansible_python_version | version_compare('3.0.0', '<')) else 'python3-psycopg2' }}"
     - "{{ 'acl' if ('SUDO_USER' in ansible_env and ansible_env.SUDO_USER != 'root') else [] }}"
-

--- a/tasks/install_packages_yum.yml
+++ b/tasks/install_packages_yum.yml
@@ -10,9 +10,8 @@
     state: latest
     update_cache: yes
   with_items:
-    - "{{ netbox_python3_packages if (netbox_python == 3) else netbox_python2_packages }}"
+    - "{{ netbox_python_packages }}"
     - "{{ netbox_packages }}"
     - "{{ netbox_ldap_packages if netbox_ldap_enabled else [] }}"
     - "{{ 'git' if netbox_git else [] }}"
-    - python-psycopg2
     - "{{ 'acl' if ('SUDO_USER' in ansible_env and ansible_env.SUDO_USER != 'root') else [] }}"

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -15,28 +15,6 @@
     group: "{{ netbox_group }}"
     state: directory
 
-- name: Check existence of commit 643f64d, affecting MEDIA_ROOT
-  shell: 'git log --format=%H "{{ netbox_git_version }}" | grep ^643f64df3f02912957c2faf1a7555876fe00e2bc'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-  register: __netbox_git_contains_media_root_change
-  changed_when: False
-  failed_when: "__netbox_git_contains_media_root_change.rc not in [0, 1]"
-
-- name: Ensure MEDIA_ROOT is defined if commit 643f64d exists
-  fail:
-    msg: "Please define MEDIA_ROOT in netbox_config."
-  when:
-    - __netbox_git_contains_media_root_change.rc == 0 and "MEDIA_ROOT" not in netbox_config
-
-- name: Check existence of commit 97188ad, fixing issue netbox#1563
-  shell: 'git log --format=%H "{{ netbox_git_version }}" | grep ^97188ad85ba77d361ae38d8b5e01ae9109e5e9bd'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-  register: __netbox_git_contains_issue_1563_fix
-  changed_when: False
-  failed_when: "__netbox_git_contains_issue_1563_fix.rc not in [0, 1]"
-
 - name: Archive and extract snapshot of git repository
   shell: 'git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:
@@ -44,7 +22,7 @@
   notify:
     - reload netbox.service
   when:
-    - __netbox_git_repo | changed
+    - __netbox_git_repo is changed
   become: True
   become_user: "{{ netbox_user }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   pip:
     name: virtualenv
     state: latest
-    executable: "{{ netbox_pip3_binary if (netbox_python == 3) else netbox_pip2_binary }}"
+    executable: "{{ netbox_pip_binary }}"
 
 - name: Create NetBox user group
   group:
@@ -56,7 +56,7 @@
   pip:
     name: uwsgi
     state: latest
-    executable: "{{ netbox_pip3_binary if (netbox_python == 3) else netbox_pip2_binary }}"
+    executable: "{{ netbox_pip_binary }}"
   notify:
     - reload netbox.service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for lae.netbox
-- include: validate_variables.yml
+- import_tasks: validate_variables.yml
 
 - name: Gather OS specific variables
   include_vars: "{{ item }}"
@@ -10,7 +10,7 @@
     - "{{ ansible_distribution|lower }}.yml"
     - "{{ ansible_os_family|lower }}.yml"
 
-- include: "install_packages_{{ ansible_pkg_mgr }}.yml"
+- include_tasks: "install_packages_{{ ansible_pkg_mgr }}.yml"
 
 - name: Install virtualenv via pip
   pip:
@@ -50,7 +50,7 @@
     - netbox_database_socket is not defined
     - netbox_database_host is defined
 
-- include: deploy_netbox.yml
+- import_tasks: deploy_netbox.yml
 
 - name: Install uWSGI via pip
   pip:

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -25,6 +25,11 @@
   when:
     - netbox_database_socket is defined and netbox_database_host is defined
 
+- name: Ensure ALLOWED_HOSTS is defined
+  fail:
+    msg: "Please define ALLOWED_HOSTS in netbox_config."
+  when: "'ALLOWED_HOSTS' not in netbox_config"
+
 - name: Ensure NAPALM_USERNAME/PASSWORD is defined for NAPALM integration
   fail:
     msg: "Please define NAPALM_USERNAME and NAPALM_PASSWORD in netbox_config to use NAPALM."
@@ -34,5 +39,9 @@
 - name: Ensure MEDIA_ROOT is defined
   fail:
     msg: "Please define MEDIA_ROOT in netbox_config."
-  when:
-    - netbox_stable and netbox_stable_version | version_compare('2.1.4', '<') and "MEDIA_ROOT" not in netbox_config
+  when: "'MEDIA_ROOT' not in netbox_config"
+
+- name: Ensure REPORTS_ROOT is defined
+  fail:
+    msg: "Please define REPORTS_ROOT in netbox_config."
+  when: "'REPORTS_ROOT' not in netbox_config"

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -25,12 +25,6 @@
   when:
     - netbox_database_socket is defined and netbox_database_host is defined
 
-- name: Ensure Python version is valid
-  fail:
-    msg: "Please set netbox_python to either 2 or 3."
-  when:
-    - netbox_python not in [2, 3]
-
 - name: Ensure NAPALM_USERNAME/PASSWORD is defined for NAPALM integration
   fail:
     msg: "Please define NAPALM_USERNAME and NAPALM_PASSWORD in netbox_config to use NAPALM."

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -11,7 +11,7 @@ DATABASE = {
 {% endif %}
 }
 
-{% for setting, value in netbox_config.iteritems() %}
+{% for setting, value in netbox_config.items() %}
 {% if value in [True, False] %}
 {{ setting }} = {{ 'True' if value else 'False' }}
 {% else %}

--- a/tests/group_vars/netbox
+++ b/tests/group_vars/netbox
@@ -5,6 +5,7 @@ netbox_config:
   ALLOWED_HOSTS:
     - "{{ inventory_hostname }}"
   MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+  REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
 netbox_superuser_password: netbox
 netbox_database: "netbox_{{ inventory_hostname_short }}"
 netbox_database_host: 10.0.3.1

--- a/tests/group_vars/netbox-git
+++ b/tests/group_vars/netbox-git
@@ -1,2 +1,3 @@
 ---
 netbox_git: true
+netbox_git_version: develop-2.4

--- a/tests/group_vars/netbox-git
+++ b/tests/group_vars/netbox-git
@@ -1,3 +1,2 @@
 ---
 netbox_git: true
-netbox_git_version: develop-2.4

--- a/tests/group_vars/netbox-python2
+++ b/tests/group_vars/netbox-python2
@@ -1,2 +1,0 @@
----
-netbox_python: 2

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -6,6 +6,7 @@
   vars:
     test_profiles:
       - profile: debian-stretch
+      - profile: ubuntu-bionic
       - profile: ubuntu-xenial
       - profile: centos-7
     test_host_suffixes:

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -9,7 +9,5 @@
       - profile: ubuntu-xenial
       - profile: centos-7
     test_host_suffixes:
-      - py3-stable
-      - py2-stable
-      - py3-git
-      - py2-git
+      - stable
+      - git

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -10,5 +10,4 @@
       - profile: ubuntu-xenial
       - profile: centos-7
     test_host_suffixes:
-      - stable
       - git

--- a/tests/inventory
+++ b/tests/inventory
@@ -3,19 +3,11 @@ netbox-stable
 netbox-git
 
 [netbox-stable]
-debian-stretch-py[2:3]-stable
-ubuntu-xenial-py[2:3]-stable
-centos-7-py[2:3]-stable
+debian-stretch-stable
+ubuntu-xenial-stable
+centos-7-stable
 
 [netbox-git]
-debian-stretch-py[2:3]-git
-ubuntu-xenial-py[2:3]-git
-centos-7-py[2:3]-git
-
-[netbox-python2]
-debian-stretch-py2-stable
-ubuntu-xenial-py2-stable
-centos-7-py2-stable
-debian-stretch-py2-git
-ubuntu-xenial-py2-git
-centos-7-py2-git
+debian-stretch-git
+ubuntu-xenial-git
+centos-7-git

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,12 +1,5 @@
 [netbox:children]
-netbox-stable
 netbox-git
-
-[netbox-stable]
-debian-stretch-stable
-ubuntu-bionic-stable
-ubuntu-xenial-stable
-centos-7-stable
 
 [netbox-git]
 debian-stretch-git

--- a/tests/inventory
+++ b/tests/inventory
@@ -4,10 +4,12 @@ netbox-git
 
 [netbox-stable]
 debian-stretch-stable
+ubuntu-bionic-stable
 ubuntu-xenial-stable
 centos-7-stable
 
 [netbox-git]
 debian-stretch-git
+ubuntu-bionic-git
 ubuntu-xenial-git
 centos-7-git

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -5,6 +5,7 @@ netbox_packages:
   - libxml2-devel
   - libxslt-devel
   - libffi-devel
+  - libjpeg-devel
   - graphviz
   - openssl-devel
 netbox_python_packages:

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -7,18 +7,13 @@ netbox_packages:
   - libffi-devel
   - graphviz
   - openssl-devel
-netbox_python2_packages:
-  - python2
-  - python-devel
-  - python-pip
-netbox_python2_binary: /usr/bin/python2
-netbox_pip2_binary: /usr/bin/pip2
-netbox_python3_packages:
+netbox_python_packages:
   - python34
   - python34-devel
   - python34-setuptools
   - python34-pip
-netbox_python3_binary: /usr/bin/python3.4
-netbox_pip3_binary: /usr/bin/pip3
+  - python-psycopg2
+netbox_python_binary: /usr/bin/python3.4
+netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - openldap-devel

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -6,18 +6,13 @@ netbox_packages:
   - graphviz
   - libpq-dev
   - libssl-dev
-netbox_python2_packages:
-  - python2.7
-  - python-dev
-  - python-pip
-netbox_python2_binary: /usr/bin/python2.7
-netbox_pip2_binary: /usr/bin/pip2
-netbox_python3_packages:
+netbox_python_packages:
   - python3.4
   - python3.4-dev
   - python3-pip
-netbox_python3_binary: /usr/bin/python3.4
-netbox_pip3_binary: /usr/bin/pip3
+  - python-psycopg2
+netbox_python_binary: /usr/bin/python3.4
+netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -6,18 +6,13 @@ netbox_packages:
   - graphviz
   - libpq-dev
   - libssl-dev
-netbox_python2_packages:
-  - python2.7
-  - python-dev
-  - python-pip
-netbox_python2_binary: /usr/bin/python2.7
-netbox_pip2_binary: /usr/bin/pip2
-netbox_python3_packages:
+netbox_python_packages:
   - python3.5
   - python3.5-dev
   - python3-pip
-netbox_python3_binary: /usr/bin/python3.5
-netbox_pip3_binary: /usr/bin/pip3
+  - python-psycopg2
+netbox_python_binary: /usr/bin/python3.5
+netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -3,6 +3,7 @@ netbox_packages:
   - libxml2-dev
   - libxslt1-dev
   - libffi-dev
+  - libjpeg-dev
   - graphviz
   - libpq-dev
   - libssl-dev

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for lae.netbox
 netbox_config_path: "{{ netbox_current_path }}/netbox/netbox"
-netbox_virtualenv_path: "{{ netbox_current_path }}/venv-py{{ netbox_python }}"
+netbox_virtualenv_path: "{{ netbox_current_path }}/venv-py3"
 
 netbox_superuser_script: |
   from django.contrib.auth.models import User

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -6,18 +6,13 @@ netbox_packages:
   - graphviz
   - libpq-dev
   - libssl-dev
-netbox_python2_packages:
-  - python2.7
-  - python-dev
-  - python-pip
-netbox_python2_binary: /usr/bin/python2.7
-netbox_pip2_binary: /usr/bin/pip2
-netbox_python3_packages:
+netbox_python_packages:
   - python3.5
   - python3.5-dev
   - python3-pip
-netbox_python3_binary: /usr/bin/python3.5
-netbox_pip3_binary: /usr/bin/pip3
+  - python-psycopg2
+netbox_python_binary: /usr/bin/python3.5
+netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -3,6 +3,7 @@ netbox_packages:
   - libxml2-dev
   - libxslt1-dev
   - libffi-dev
+  - libjpeg-dev
   - graphviz
   - libpq-dev
   - libssl-dev

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -8,11 +8,11 @@ netbox_packages:
   - libpq-dev
   - libssl-dev
 netbox_python_packages:
-  - python3.4
-  - python3.4-dev
+  - python3.6
+  - python3.6-dev
   - python3-pip
   - python-psycopg2
-netbox_python_binary: /usr/bin/python3.4
+netbox_python_binary: /usr/bin/python3.6
 netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev


### PR DESCRIPTION
This branch currently is not ready for production until NetBox 2.4 is released, and is intended to track changes upstream that might break deployment (there is a travis cronjob configured to test this branch daily).

You can use this branch to deploy the NetBox 2.4 branch as usual by installing it using `ansible-galaxy` like below.

```
ansible-galaxy install https://github.com/lae/ansible-role-netbox/archive/feature/netbox-2.4.tar.gz,v0.6.0-pre,lae.netbox --force
```

You must specify the following role variables to test the 2.4 branch:

```
netbox_git: true
netbox_git_version: develop-2.4
```

## Changes

* Python 2 support is dropped from the role (still supported by NetBox 2.4 but will be dropped in 2.5 - I'd rather not keep Python 2 support around if no one is configuring a Python 2 deployment with this role) - #26 
* Workarounds to fix bugs/shortcomings of NetBox <2.3 have been removed - the next version, v0.6.0 should only be used to deploy NetBox 2.3 or higher. Users should stick to v0.5.6 otherwise.
* Configuration files are now validated - prevents services from breaking - #18 
* Ubuntu 18 LTS is now supported
* Future-proofing changes for Ansible 2.6 (and one for 2.10) - minimum required Ansible version is now 2.4 
* Role is now tested with Python 3 and fixes were made to support Python 3

If you'd like to see anything added, deployment-wise, in the next release, feel free to open an issue.