### PR TITLE
Add support for Ubuntu Bionic (18.04)

### DIFF
--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -42,3 +42,13 @@
     msg: "Please define MEDIA_ROOT in netbox_config."
   when:
     - netbox_stable and netbox_stable_version | version_compare('2.1.4', '<') and "MEDIA_ROOT" not in netbox_config
+
+# TODO(mnaser): Remove this once Netbox starts using Django 2 which resolves
+#               the Python 3.7 compatibility.
+- name: Ensure using Python 2.7 on Ubuntu Bionic (18.04)
+  fail:
+    msg: "Ubuntu 18.04 does not ship with Python 3.5, it ships with 3.7 which is not compatible with Netbox, please use Python 2.7"
+  when:
+    - netbox_python == '3'
+    - ansible_distribution|lower == 'ubuntu'
+    - ansible_distribution_major_version == '18'

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -6,6 +6,7 @@
   vars:
     test_profiles:
       - profile: debian-stretch
+      - profile: ubuntu-bionic
       - profile: ubuntu-xenial
       - profile: centos-7
     test_host_suffixes:

--- a/tests/inventory
+++ b/tests/inventory
@@ -4,18 +4,22 @@ netbox-git
 
 [netbox-stable]
 debian-stretch-py[2:3]-stable
+ubuntu-bionic-py2-stable
 ubuntu-xenial-py[2:3]-stable
 centos-7-py[2:3]-stable
 
 [netbox-git]
 debian-stretch-py[2:3]-git
+ubuntu-bionic-py2-git
 ubuntu-xenial-py[2:3]-git
 centos-7-py[2:3]-git
 
 [netbox-python2]
 debian-stretch-py2-stable
+ubuntu-bionic-py2-stable
 ubuntu-xenial-py2-stable
 centos-7-py2-stable
 debian-stretch-py2-git
+ubuntu-bionic-py2-git
 ubuntu-xenial-py2-git
 centos-7-py2-git

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -1,0 +1,23 @@
+---
+netbox_packages:
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - graphviz
+  - libpq-dev
+  - libssl-dev
+netbox_python2_packages:
+  - python2.7
+  - python-dev
+  - python-pip
+netbox_python2_binary: /usr/bin/python2.7
+netbox_pip2_binary: /usr/bin/pip2
+netbox_python3_packages:
+  - python3.7
+  - python3.7-dev
+  - python3-pip
+netbox_python3_binary: /usr/bin/python3.5
+netbox_pip3_binary: /usr/bin/pip3
+netbox_ldap_packages:
+  - libldap2-dev
+  - libsasl2-dev


### PR DESCRIPTION
This patch adds support for Ubuntu Bionic (18.04) alongside with
all the changes required in order to add testing in Travis CI.

Due to the fact that Ubuntu Bionic only ships with Python 3.7 which
is not supported by Django 1.x which Netbox uses, this patch makes
sure that it is only deployed using Python 2.7.