### PR TITLE
Run Ansible with Python 3 once installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,13 +10,23 @@
     - "{{ ansible_distribution|lower }}.yml"
     - "{{ ansible_os_family|lower }}.yml"
 
+- name: Determine whether to switch Ansible's interpreter
+  set_fact:
+    netbox_switch_ansible_python: "{{ _netbox_switch_ansible_python | default(True) }}"
+  when: netbox_switch_ansible_python is not defined
+
 - include_tasks: "install_packages_{{ ansible_pkg_mgr }}.yml"
+
+- name: Switch Ansible's Python interpreter to Python 3
+  set_fact:
+    ansible_python_interpreter: "{{ netbox_python_binary }}"
+  when: netbox_switch_ansible_python
 
 - name: Install virtualenv via pip
   pip:
     name: virtualenv
     state: latest
-    executable: "{{ netbox_pip_binary }}"
+    executable: /usr/bin/pip3
 
 - name: Create NetBox user group
   group:
@@ -56,7 +66,7 @@
   pip:
     name: uwsgi
     state: latest
-    executable: "{{ netbox_pip_binary }}"
+    executable: /usr/bin/pip3
   notify:
     - reload netbox.service
 

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -13,8 +13,9 @@ netbox_python_packages:
   - python34-devel
   - python34-setuptools
   - python34-pip
-  - python-psycopg2
+  - python-setuptools # used by ansible's pip module
+  - python-psycopg2 # used by ansible's postgres modules
+_netbox_switch_ansible_python: False
 netbox_python_binary: /usr/bin/python3.4
-netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - openldap-devel

--- a/vars/debian-8.yml
+++ b/vars/debian-8.yml
@@ -11,9 +11,10 @@ netbox_python_packages:
   - python3.4
   - python3.4-dev
   - python3-pip
-  - python-psycopg2
+  - python-setuptools # used by ansible's pip module
+  - python-psycopg2 # used by ansible's postgres modules
+_netbox_switch_ansible_python: False
 netbox_python_binary: /usr/bin/python3.4
-netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/debian-9.yml
+++ b/vars/debian-9.yml
@@ -11,9 +11,8 @@ netbox_python_packages:
   - python3.5
   - python3.5-dev
   - python3-pip
-  - python-psycopg2
+  - python3-psycopg2 # used by ansible's postgres modules
 netbox_python_binary: /usr/bin/python3.5
-netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/ubuntu-16.yml
+++ b/vars/ubuntu-16.yml
@@ -11,9 +11,8 @@ netbox_python_packages:
   - python3.5
   - python3.5-dev
   - python3-pip
-  - python-psycopg2
+  - python3-psycopg2 # used by ansible's postgres modules
 netbox_python_binary: /usr/bin/python3.5
-netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -11,9 +11,8 @@ netbox_python_packages:
   - python3.6
   - python3.6-dev
   - python3-pip
-  - python-psycopg2
+  - python3-psycopg2 # used by ansible's postgres modules
 netbox_python_binary: /usr/bin/python3.6
-netbox_pip_binary: /usr/bin/pip3
 netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev


### PR DESCRIPTION
Except on distros with an unsupported version (which instead gets Python 2 setuptools installed).

https://github.com/ansible/ansible/issues/9515 introduced a dependency on setuptools in the pip module for Ansible 2.7.