### PR TITLE
Use pip constraints

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,7 @@ netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 
 netbox_napalm_enabled: false
+
+netbox_pip_constraints:
+  # Blacklist pynacl 1.3.0 due to https://github.com/pyca/pynacl/issues/479
+  - 'pynacl!=1.3.0'

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -17,17 +17,17 @@
   when:
     - netbox_config.SECRET_KEY is not defined
 
-- name: Pin django-filter dependency to under 2.0.0 for NetBox 2.3.5 and below
-  replace:
-    path: "{{ netbox_current_path }}/requirements.txt"
-    regexp: '^(django-filter>=\d+\.\d+(\.\d+)?)$'
-    replace: '\1,<2.0.0'
-  when:
-    - (netbox_stable and netbox_stable_version | version_compare('2.3.5', '<=')) or (netbox_git and __netbox_git_contains_issue_2239_fix.rc == 1)
+- name: Drop pip constraints file
+  template:
+    src: pip_constraints.j2
+    dest: "{{ netbox_current_path }}/constraints.txt"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_group }}"
 
 - name: Create NetBox virtualenv and install needed Python dependencies
   pip:
     requirements: "{{ netbox_current_path }}/requirements.txt"
+    extra_args: "-c {{ netbox_current_path }}/constraints.txt"
     virtualenv: "{{ netbox_virtualenv_path }}"
     virtualenv_python: "{{ netbox_python_binary }}"
   become: True

--- a/templates/pip_constraints.j2
+++ b/templates/pip_constraints.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+{% if (netbox_stable and netbox_stable_version | version_compare('2.3.5', '<=')) or
+      (netbox_git and __netbox_git_contains_issue_2239_fix.rc == 1) %}
+django-filter<2.0.0
+{% endif %}
+
+{% for constraint in netbox_pip_constraints %}
+{{ constraint }}
+{% endfor %}


### PR DESCRIPTION
Instead of using string replacements on requirements.txt, use pip constraints
to limit package versions. Also add a variable 'netbox_pip_constraints' to
allow constraints defined outside the role.

This also blacklists pynacl 1.3.0 due to the issues described at
https://github.com/pyca/pynacl/issues/479 causing build failures on many
environments that do not have 'make' involved due to missing wheel builds.