### PR TITLE
napalm: allow using custom package list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,8 @@ netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 
 netbox_napalm_enabled: false
+netbox_napalm_packages:
+  - napalm
 
 netbox_pip_constraints:
   # Blacklist pynacl 1.3.0 due to https://github.com/pyca/pynacl/issues/479

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -90,7 +90,7 @@
 
 - name: Install napalm if NAPALM integration is enabled
   pip:
-    name: napalm
+    name: "{{ netbox_napalm_packages }}"
     virtualenv: "{{ netbox_virtualenv_path }}"
   when:
     - netbox_napalm_enabled


### PR DESCRIPTION
This change will allow the deployer to use a custom NAPALM package
list which will allow them to use community drivers for devices
that are not natively supported via NAPALM (such as RouterOS).