### PR TITLE
Allow role to run successfully in --check mode

### DIFF
--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -31,7 +31,9 @@
   shell: "echo $PATH"
   register: _path_exec
   changed_when: false
+  check_mode: false
 
 - name: Set a fact for current execution PATH
   set_fact:
     _path: "{{ _path_exec.stdout }}"
+  check_mode: false


### PR DESCRIPTION
In check-mode, the register task for _path_exec isn't executed, which then fails the set_fact task after it.
Since these are safe to run in check-mode, i've added the check_mode:false flag.