### PR TITLE
Support deeply nested configurations

### DIFF
--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -1,3 +1,5 @@
+import json
+
 {{ ansible_managed | comment }}
 DATABASE = {
     'NAME': '{{ netbox_database }}',
@@ -13,7 +15,7 @@ DATABASE = {
 
 {% if netbox_webhooks_enabled %}
 WEBHOOKS_ENABLED = True
-REDIS = { 
+REDIS = {
     'HOST': '{{ netbox_redis_host }}',
     'PORT': '{{ netbox_redis_port }}',
     'PASSWORD': '{{ netbox_redis_password }}',
@@ -25,8 +27,10 @@ REDIS = {
 {% for setting, value in netbox_config.items() %}
 {% if value in [True, False] %}
 {{ setting }} = {{ 'True' if value else 'False' }}
-{% else %}
+{% elif value is string or value is number %}
 {{ setting }} = {{ value | to_nice_json }}
+{% else %}
+{{ setting }} = json.loads(r'''{{ value | to_json }}''')
 {% endif %}
 {% endfor %}
 

--- a/tests/group_vars/netbox
+++ b/tests/group_vars/netbox
@@ -5,7 +5,13 @@ netbox_config:
     - "{{ inventory_hostname }}"
   MEDIA_ROOT: "{{ netbox_shared_path }}/media"
   REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
+  NAPALM_USERNAME: manager
+  NAPALM_PASSWORD: null
+  NAPALM_ARGS:
+    use_keys: true
+    key_file: '/srv/netbox/.ssh/id_rsa'
 
+netbox_napalm_enabled: true
 netbox_superuser_password: netbox
 netbox_database: "netbox_{{ inventory_hostname_short }}"
 netbox_database_host: 10.0.3.1


### PR DESCRIPTION
A configuration value can become deeply nested especially 
when dealing with `NAPALM_ARGS`.  In this scenario the 
approach to dump the configuration tree with `to_nice_json`
can lead to the creation of a configuration file that is not
valid Python anymore.  Store these values as strings in the
`configuration.py` file and load them with `json.loads`.