### PR TITLE
Improves Jinja2 syntax for multi-line case for ansible_managed

### DIFF
--- a/examples/netbox_ldap_config.py.j2
+++ b/examples/netbox_ldap_config.py.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 import ldap
 from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
 


### PR DESCRIPTION
In case of multi line setup for ansible_managed, validate task for ldap config are broken and netbox cannot start.

This fix permit to insert comment for all line.