### PR TITLE
NetBox 2.7 release preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .history
 *.retry
+*.code-workspace

--- a/README.adoc
+++ b/README.adoc
@@ -162,11 +162,18 @@ netbox_redis_host: 127.0.0.1
 netbox_redis_port: 6379
 netbox_redis_password: ''
 netbox_redis_database: 0
-netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
+netbox_redis_ssl_enabled: false
+
+netbox_redis_cache_host: "{{ netbox_redis_host }}"
+netbox_redis_cache_port: "{{ netbox_redis_port }}"
+netbox_redis_cache_database: 1
+netbox_redis_cache_password: "{{ netbox_redis_password }}"
+netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
+netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
 ----
 
-This populates the `REDIS` config dictionary in `configuration.py`.
+This populates the `REDIS` config dictionary in `configuration.py`. Utilize the second set of variables if you wish to seperate your cache database from your webhooks database.
 
 [source,yaml]
 ----
@@ -307,11 +314,6 @@ Toggle `netbox_napalm_enabled` to enable NAPALM integration in NetBox. You must
 define `NAPALM_USERNAME` and `NAPALM_PASSWORD` in the `netbox_config` variable
 to be able to use NAPALM. Add extra NAPALM python libraries by listing them in
 `netbox_napalm_packages` (e.g. `napalm-eos`).
-
-[source,yaml]
-netbox_webhooks_enabled: false
-
-Toggle `netbox_webhooks_enabled` to `true` to enable webhooks for NetBox.
 
 [source,yaml]
 netbox_metrics_enabled: true

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :role-name: netbox
 :role: {role-author}.{role-name}
 :gh-name: {role-author}/ansible-role-{role-name}
-:netbox-version: 2.7.6
+:netbox-version: 2.7.9
 = {role}
 :toc:
 :toc-placement: preamble

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :role-name: netbox
 :role: {role-author}.{role-name}
 :gh-name: {role-author}/ansible-role-{role-name}
-:netbox-version: 2.6.12
+:netbox-version: 2.7.6
 = {role}
 :toc:
 :toc-placement: preamble

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.6.12
+netbox_stable_version: 2.7.6
 netbox_stable_uri: "https://github.com/digitalocean/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false
-netbox_git_version: v2.6.12
+netbox_git_version: develop
 netbox_git_uri: "https://github.com/digitalocean/netbox.git"
 
 netbox_install_epel: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.7.6
+netbox_stable_version: 2.7.9
 netbox_stable_uri: "https://github.com/digitalocean/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,11 +26,15 @@ netbox_redis_host: 127.0.0.1
 netbox_redis_port: 6379
 netbox_redis_password: ''
 netbox_redis_database: 0
-netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
 netbox_redis_ssl_enabled: false
 
-netbox_webhooks_enabled: false
+netbox_redis_cache_host: "{{ netbox_redis_host }}"
+netbox_redis_cache_port: "{{ netbox_redis_port }}"
+netbox_redis_cache_database: 1
+netbox_redis_cache_password: "{{ netbox_redis_password }}"
+netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
+netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
 
 netbox_metrics_enabled: false
 netbox_metrics_dir: netbox_metrics

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -38,14 +38,12 @@
   register: _netbox_virtualenv_setup
   until: _netbox_virtualenv_setup is succeeded
 
-- name: Install django-rq if webhooks enabled
+- name: Install django-rq
   pip:
     name: "django-rq"
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: True
   become_user: "{{ netbox_user }}"
-  when:
-    - netbox_webhooks_enabled
   retries: 2
   register: _netbox_django_rq_install
   until: _netbox_django_rq_install is succeeded

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -38,15 +38,18 @@
   register: _netbox_virtualenv_setup
   until: _netbox_virtualenv_setup is succeeded
 
-- name: Install django-rq
+- name: Install selected optional Python dependencies
   pip:
-    name: "django-rq"
+    name: "{{ item }}"
+    state: present
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: True
   become_user: "{{ netbox_user }}"
   retries: 2
-  register: _netbox_django_rq_install
-  until: _netbox_django_rq_install is succeeded
+  register: _netbox_pip_additional_install
+  until: _netbox_pip_additional_install is succeeded
+  when: (_netbox_python_deps | length) > 0
+  loop: "{{ _netbox_python_deps }}"
 
 - name: Generate NetBox configuration file
   template:
@@ -61,43 +64,20 @@
   notify:
     - reload netbox.service
 
-- block:
-  - name: Install django-auth-ldap if LDAP is enabled
-    pip:
-      name: django-auth-ldap
-      virtualenv: "{{ netbox_virtualenv_path }}"
-    become: True
-    become_user: "{{ netbox_user }}"
-    retries: 2
-    register: _netbox_django_auth_ldap_install
-    until: _netbox_django_auth_ldap_install is succeeded
-
-  - name: Generate LDAP configuration for NetBox if enabled
-    template:
-      src: "{{ netbox_ldap_config_template }}"
-      dest: "{{ netbox_shared_path }}/ldap_config.py"
-      owner: "{{ netbox_user }}"
-      group: "{{ netbox_group }}"
-      mode: 0640
-      validate: "{{ netbox_virtualenv_path }}/bin/python -c \"import py_compile,os; f=r'%s';\
-                 c='/tmp/' + os.path.basename(os.path.dirname(f)) + '-' + os.path.basename(f) + 'c';\
-                 py_compile.compile(f, c); os.remove(c)\""
-    notify:
-      - reload netbox.service
+- name: Generate LDAP configuration for NetBox if enabled
+  template:
+    src: "{{ netbox_ldap_config_template }}"
+    dest: "{{ netbox_shared_path }}/ldap_config.py"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_group }}"
+    mode: 0640
+    validate: "{{ netbox_virtualenv_path }}/bin/python -c \"import py_compile,os; f=r'%s';\
+                c='/tmp/' + os.path.basename(os.path.dirname(f)) + '-' + os.path.basename(f) + 'c';\
+                py_compile.compile(f, c); os.remove(c)\""
+  notify:
+    - reload netbox.service
   when:
     - netbox_ldap_enabled
-
-- name: Install napalm if NAPALM integration is enabled
-  pip:
-    name: "{{ netbox_napalm_packages }}"
-    virtualenv: "{{ netbox_virtualenv_path }}"
-  when:
-    - netbox_napalm_enabled
-  become: True
-  become_user: "{{ netbox_user }}"
-  retries: 2
-  register: _netbox_napalm_install
-  until: _netbox_napalm_install is succeeded
 
 - name: Symlink NetBox configuration file into the active NetBox release
   file:

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -27,6 +27,18 @@
     netbox_ldap_packages: "{{ _netbox_ldap_packages | list }}"
   when: netbox_ldap_packages is not defined
 
+- name: Generate list of optional Python dependencies
+  set_fact:
+    _netbox_python_deps:
+      - "{{ netbox_napalm_packages if netbox_napalm_enabled else [] }}"
+      - "{{ 'django-auth-ldap' if netbox_ldap_enabled else [] }}"
+      - "{{ 'django-storages' if _netbox_storages_module is defined else [] }}"
+      - "{{ _netbox_storages_map[_netbox_storages_module] if _netbox_storages_module is defined else [] }}"
+
+- name: Flatten that list of dependencies
+  set_fact:
+    _netbox_python_deps: "{{ _netbox_python_deps | flatten }}"
+
 - name: Identify current execution PATH
   shell: "echo $PATH"
   register: _path_exec

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,8 +85,6 @@
     dest: /lib/systemd/system/netbox-rqworker.service
   notify:
     - restart netbox-rqworker.service
-  when:
-    - netbox_webhooks_enabled
 
 - name: Start and enable NetBox' socket and service
   systemd:
@@ -102,5 +100,3 @@
     name: netbox-rqworker.service
     state: started
     enabled: yes
-  when:
-    - netbox_webhooks_enabled

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -56,3 +56,15 @@
       - "(netbox_scripts | map(attribute='name') | map('regex_search', '^[a-z][a-z0-9_]*$') | select('string') | list | length) == (netbox_scripts | length)"
       - "(netbox_reports | map(attribute='name') | map('regex_search', '^[a-z][a-z0-9_]*$') | select('string') | list | length) == (netbox_reports | length)"
     msg: "Please ensure that your script/report module names start with a lowercase letter and contain only lowercase letters, numbers, and underscores."
+
+- block:
+  - name: Identify selected storage module
+    set_fact:
+      _netbox_storages_module: "{{ netbox_config.STORAGE_BACKEND | regex_search('(?<=storages\\.backends\\.).*(?=\\.)') }}"
+
+  - name: Ensure storage module is a valid option
+    assert:
+      that:
+        - _netbox_storages_module in _netbox_storages_map
+      msg: "Please ensure your STORAGE_BACKEND is correct."
+  when: "'STORAGE_BACKEND' in netbox_config"

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -27,18 +27,23 @@ DATABASE = {
 }
 
 REDIS = {
-    'HOST': '{{ netbox_redis_host }}',
-    'PORT': '{{ netbox_redis_port }}',
-    'PASSWORD': '{{ netbox_redis_password }}',
-    'DATABASE': '{{ netbox_redis_database }}',
-    'CACHE_DATABASE': '{{ netbox_redis_cache_database }}',
-    'DEFAULT_TIMEOUT': '{{ netbox_redis_default_timeout }}',
-    'SSL': {{ netbox_redis_ssl_enabled }},
+    'webhooks': {
+        'HOST': '{{ netbox_redis_host }}',
+        'PORT': {{ netbox_redis_port }},
+        'PASSWORD': '{{ netbox_redis_password }}',
+        'DATABASE': {{ netbox_redis_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_default_timeout }},
+        'SSL': {{ netbox_redis_ssl_enabled }},
+    },
+    'caching': {
+        'HOST': '{{ netbox_redis_cache_host }}',
+        'PORT': {{ netbox_redis_cache_port }},
+        'PASSWORD': '{{ netbox_redis_cache_password }}',
+        'DATABASE': {{ netbox_redis_cache_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_cache_default_timeout }},
+        'SSL': {{ netbox_redis_cache_ssl_enabled }},
+    }
 }
-
-{% if netbox_webhooks_enabled %}
-WEBHOOKS_ENABLED = True
-{% endif %}
 
 {% if netbox_metrics_enabled %}
 METRICS_ENABLED = True

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,15 @@
 netbox_config_path: "{{ netbox_current_path }}/netbox/netbox"
 netbox_virtualenv_path: "{{ netbox_current_path }}/venv-py3"
 
+_netbox_storages_map:
+  s3boto3: boto3
+  apache_libcloud: "apache-libcloud"
+  azure_storage: "django-storages[azure]"
+  dropbox: "django-storages[dropbox]"
+  gcloud: "django-storages[google]"
+  ftp: []
+  sftpstorage: []
+
 netbox_superuser_script: |
   from django.contrib.auth.models import User
   from base64 import b64decode


### PR DESCRIPTION
In the same vein as #40, this branch will track upstream NetBox 2.7 development. Do not use this in production.

To deploy NetBox 2.7, use `ansible-galaxy` to install this branch:

```
ansible-galaxy install https://github.com/lae/ansible-role-netbox/archive/feature/netbox-2.7.tar.gz,v0.9.0-pre,lae.netbox --force
```

~~Using `netbox_stable` will use the latest beta (currently `2.7-beta1`), whilst using `netbox_git` will grab you the latest from the `develop-2.7` branch in NetBox.~~

For those wanting to test out 2.7, please report back here if you run into any issues that might be related to deployment (for anything that is a bug in NetBox itself, please [report it upstream](https://github.com/digitalocean/netbox/issues)).

## Changes

If I'm missing anything, please leave a comment.
 
- ~~Requirement conditions for Python 3.6+~~ (postponed for NetBox 2.8)
- #79 External file storage logic (**Merged**)
- #77 Redis configuration logic for separate connections (**Merged**)
- #81 Report uploads (**Merged**)
- #82 manage.py clearsessions (**Merged**)
