### PR TITLE
add ssl option for redis

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ netbox_redis_password: ''
 netbox_redis_database: 0
 netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
+netbox_redis_ssl_enabled: false
 
 netbox_webhooks_enabled: false
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,6 +14,7 @@
         - "*"
       MEDIA_ROOT: "{{ netbox_shared_path }}/media"
       REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
+      SCRIPTS_ROOT: "{{ netbox_shared_path }}/scripts"
     netbox_database_socket: "{{ postgresql_unix_socket_directories[0] }}"
     # webhooks
     netbox_webhooks_enabled: true

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -21,6 +21,7 @@ REDIS = {
     'DATABASE': '{{ netbox_redis_database }}',
     'CACHE_DATABASE': '{{ netbox_redis_cache_database }}',
     'DEFAULT_TIMEOUT': '{{ netbox_redis_default_timeout }}',
+    'SSL': {{ netbox_redis_ssl_enabled }},
 }
 
 {% if netbox_webhooks_enabled %}


### PR DESCRIPTION
Related to issue #72 

Adds option to enable SSL for Redis connection for Netbox release 2.6. This is mainly needed when using managed Redis service like AWS ElastiCache. Also added the path for SCRIPTS_ROOT to playbook.yml used by molecule to pass the local tests. The CI tests seem to fail because of incompatibility with Netbox release 2.7.