### PR TITLE
MVP for 2.7 Install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.7-beta1
+netbox_stable_version: 2.7.4
 netbox_stable_uri: "https://github.com/digitalocean/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false
@@ -28,6 +28,7 @@ netbox_redis_password: ''
 netbox_redis_database: 0
 netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
+netbox_redis_ssl_enabled: False
 
 netbox_webhooks_enabled: false
 

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -37,3 +37,10 @@
   set_fact:
     _path: "{{ _path_exec.stdout }}"
   check_mode: false
+
+- name: Check for Version > 2.7
+  set_fact:
+    netbox_new_redis: True
+    netbox_webhooks_enabled: True
+  when: (netbox_stable_version is version('2.7', 'gt') and netbox_stable == True) or
+        ((netbox_git_version is version('2.7', 'gt' or netbox_git_version is search("*2.7*")) and netbox_git == True)

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -38,9 +38,9 @@
     _path: "{{ _path_exec.stdout }}"
   check_mode: false
 
-- name: Check for Version > 2.7
+- name: Check for Version >= 2.7
   set_fact:
     netbox_new_redis: True
     netbox_webhooks_enabled: True
-  when: (netbox_stable_version is version('2.7', 'gt') and netbox_stable == True) or
-        ((netbox_git_version is version('2.7', 'gt' or netbox_git_version is search("*2.7*")) and netbox_git == True)
+  when: (netbox_stable_version is version('2.7', 'ge') and netbox_stable == True) or
+        ((netbox_git_version is version('2.7', 'ge') or netbox_git_version is search("*2.7*")) and netbox_git == True)

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -14,6 +14,27 @@ DATABASE = {
     'CONN_MAX_AGE': {{ netbox_database_conn_age }},
 }
 
+{% if netbox_new_redis %}
+REDIS = {
+        'webhooks': {
+        'HOST': '{{ netbox_redis_host }}',
+        'PORT': {{ netbox_redis_port }},
+        'PASSWORD': '{{ netbox_redis_password }}',
+        'DATABASE': {{ netbox_redis_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_default_timeout }},
+        'SSL': {{ netbox_redis_ssl_enabled }},
+    },
+    'caching': {
+        'webhooks': {
+        'HOST': '{{ netbox_redis_host }}',
+        'PORT': {{ netbox_redis_port }},
+        'PASSWORD': '{{ netbox_redis_password }}',
+        'DATABASE': {{ netbox_redis_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_default_timeout }},
+        'SSL': {{ netbox_redis_ssl_enabled }},
+    }
+}
+{% else %}
 REDIS = {
     'HOST': '{{ netbox_redis_host }}',
     'PORT': '{{ netbox_redis_port }}',
@@ -21,10 +42,12 @@ REDIS = {
     'DATABASE': '{{ netbox_redis_database }}',
     'CACHE_DATABASE': '{{ netbox_redis_cache_database }}',
     'DEFAULT_TIMEOUT': '{{ netbox_redis_default_timeout }}',
+    'SSL': {{ netbox_redis_ssl_enabled }},
 }
 
 {% if netbox_webhooks_enabled %}
 WEBHOOKS_ENABLED = True
+{% endif %}
 {% endif %}
 
 {% for setting, value in netbox_config.items() %}


### PR DESCRIPTION
This creates the redis DB in the new format for 2.7+ installs. Not heavily tested, I just needed to get something working for my environment and figured I would commit it back if it is helpful.