### PR TITLE
Support separate Redis connection config for cache database

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,11 +162,11 @@ netbox_redis_host: 127.0.0.1
 netbox_redis_port: 6379
 netbox_redis_password: ''
 netbox_redis_database: 0
-netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
+netbox_redis_ssl_enabled: false
 ----
 
-This populates the `REDIS` config dictionary in `configuration.py`.
+This populates the `REDIS` config dictionary in `configuration.py`. Utilize the second set of variables if you wish to seperate your cache database from your webhooks database.
 
 [source,yaml]
 ----
@@ -299,11 +299,6 @@ Toggle `netbox_napalm_enabled` to enable NAPALM integration in NetBox. You must
 define `NAPALM_USERNAME` and `NAPALM_PASSWORD` in the `netbox_config` variable
 to be able to use NAPALM. Add extra NAPALM python libraries by listing them in
 `netbox_napalm_packages` (e.g. `napalm-eos`).
-
-[source,yaml]
-netbox_webhooks_enabled: false
-
-Toggle `netbox_webhooks_enabled` to `true` to enable webhooks for NetBox.
 
 [source,yaml]
 netbox_keep_uwsgi_updated: false

--- a/README.adoc
+++ b/README.adoc
@@ -164,6 +164,13 @@ netbox_redis_password: ''
 netbox_redis_database: 0
 netbox_redis_default_timeout: 300
 netbox_redis_ssl_enabled: false
+
+netbox_redis_cache_host: "{{ netbox_redis_host }}"
+netbox_redis_cache_port: "{{ netbox_redis_port }}"
+netbox_redis_cache_database: 1
+netbox_redis_cache_password: "{{ netbox_redis_password }}"
+netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
+netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
 ----
 
 This populates the `REDIS` config dictionary in `configuration.py`. Utilize the second set of variables if you wish to seperate your cache database from your webhooks database.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,11 +26,15 @@ netbox_redis_host: 127.0.0.1
 netbox_redis_port: 6379
 netbox_redis_password: ''
 netbox_redis_database: 0
-netbox_redis_cache_database: 1
 netbox_redis_default_timeout: 300
 netbox_redis_ssl_enabled: false
 
-netbox_webhooks_enabled: false
+netbox_redis_cache_host: "{{ netbox_redis_host }}"
+netbox_redis_cache_port: "{{ netbox_redis_port }}"
+netbox_redis_cache_database: 1
+netbox_redis_cache_password: "{{ netbox_redis_password }}"
+netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
+netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
 
 netbox_config:
   #SECRET_KEY:

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -38,14 +38,12 @@
   register: _netbox_virtualenv_setup
   until: _netbox_virtualenv_setup is succeeded
 
-- name: Install django-rq if webhooks enabled
+- name: Install django-rq
   pip:
     name: "django-rq"
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: True
   become_user: "{{ netbox_user }}"
-  when:
-    - netbox_webhooks_enabled
   retries: 2
   register: _netbox_django_rq_install
   until: _netbox_django_rq_install is succeeded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,8 +85,6 @@
     dest: /lib/systemd/system/netbox-rqworker.service
   notify:
     - restart netbox-rqworker.service
-  when:
-    - netbox_webhooks_enabled
 
 - name: Start and enable NetBox' socket and service
   systemd:
@@ -102,5 +100,3 @@
     name: netbox-rqworker.service
     state: started
     enabled: yes
-  when:
-    - netbox_webhooks_enabled

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -15,15 +15,6 @@ DATABASE = {
 }
 
 REDIS = {
-<<<<<<< HEAD
-    'HOST': '{{ netbox_redis_host }}',
-    'PORT': '{{ netbox_redis_port }}',
-    'PASSWORD': '{{ netbox_redis_password }}',
-    'DATABASE': '{{ netbox_redis_database }}',
-    'CACHE_DATABASE': '{{ netbox_redis_cache_database }}',
-    'DEFAULT_TIMEOUT': '{{ netbox_redis_default_timeout }}',
-    'SSL': {{ netbox_redis_ssl_enabled }},
-=======
     'webhooks': {
         'HOST': '{{ netbox_redis_host }}',
         'PORT': {{ netbox_redis_port }},
@@ -40,7 +31,6 @@ REDIS = {
         'DEFAULT_TIMEOUT': {{ netbox_redis_cache_default_timeout }},
         'SSL': {{ netbox_redis_cache_ssl_enabled }},
     }
->>>>>>> Support splitting webhooks/cache Redis
 }
 
 {% for setting, value in netbox_config.items() %}

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -15,6 +15,7 @@ DATABASE = {
 }
 
 REDIS = {
+<<<<<<< HEAD
     'HOST': '{{ netbox_redis_host }}',
     'PORT': '{{ netbox_redis_port }}',
     'PASSWORD': '{{ netbox_redis_password }}',
@@ -22,11 +23,25 @@ REDIS = {
     'CACHE_DATABASE': '{{ netbox_redis_cache_database }}',
     'DEFAULT_TIMEOUT': '{{ netbox_redis_default_timeout }}',
     'SSL': {{ netbox_redis_ssl_enabled }},
+=======
+    'webhooks': {
+        'HOST': '{{ netbox_redis_host }}',
+        'PORT': {{ netbox_redis_port }},
+        'PASSWORD': '{{ netbox_redis_password }}',
+        'DATABASE': {{ netbox_redis_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_default_timeout }},
+        'SSL': {{ netbox_redis_ssl_enabled }},
+    },
+    'caching': {
+        'HOST': '{{ netbox_redis_cache_host }}',
+        'PORT': {{ netbox_redis_cache_port }},
+        'PASSWORD': '{{ netbox_redis_cache_password }}',
+        'DATABASE': {{ netbox_redis_cache_database }},
+        'DEFAULT_TIMEOUT': {{ netbox_redis_cache_default_timeout }},
+        'SSL': {{ netbox_redis_cache_ssl_enabled }},
+    }
+>>>>>>> Support splitting webhooks/cache Redis
 }
-
-{% if netbox_webhooks_enabled %}
-WEBHOOKS_ENABLED = True
-{% endif %}
 
 {% for setting, value in netbox_config.items() %}
 {% if value in [True, False] %}


### PR DESCRIPTION
This adds the full modularity to the redis config by creating two sets of redis variables if you choose to use them. It also completely eliminates the webhooks variable and any references to it, since it is now a requirement for 2.7.