### PR TITLE
Report uploads and some validation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -206,22 +206,30 @@ can be used without issue). This role will attempt to create these directories
 and change their ownership to whatever `netbox_user` is set to.
 
 [source,yaml]
+----
 netbox_scripts: []
+netbox_reports: []
+----
 
 https://netbox.readthedocs.io/en/stable/additional-features/custom-scripts/[Scripts]
-to upload for use within NetBox. This should be a list of dictionaries with a
-`src` attribute, specifying the local path to the script, and a `name` attribute,
-specifying the script/module name. For example:
+and https://netbox.readthedocs.io/en/stable/additional-features/reports/[Reports]
+to upload for use within NetBox. These should be lists of dictionaries with a
+`src` attribute, specifying the local path to the script or report, and a
+`name` attribute, specifying the module name (script/report name). For example:
 
 [source,yaml]
 ----
 netbox_scripts:
   - src: netbox_scripts/migrate_application.py
     name: migrate_application
+netbox_reports:
+  - src: netbox_reports/devices.py
+    name: devices
 ----
 
-This will copy `netbox_scripts/migrate_application.py` to
-`{{ netbox_config.SCRIPTS_ROOT }}/migrate_application.py`.
+This will copy `netbox_scripts/migrate_application.py` from your playbook
+directory to `{{ netbox_config.SCRIPTS_ROOT }}/migrate_application.py` and
+`netbox_reports/devices.py` to `{{ netbox.config.REPORTS_ROOT }}/devices.py`.
 
 [source,yaml]
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ netbox_config:
   SCRIPTS_ROOT: "{{ netbox_shared_path }}/scripts"
 
 netbox_scripts: []
+netbox_reports: []
 
 netbox_user: netbox
 netbox_group: netbox

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -127,6 +127,14 @@
     group: "{{ netbox_group }}"
   loop: "{{ netbox_scripts }}"
 
+- name: Copy NetBox reports into REPORTS_ROOT
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ netbox_config.REPORTS_ROOT }}/{{ item.name }}.py"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_group }}"
+  loop: "{{ netbox_reports }}"
+
 - block:
   - name: Run database migrations for NetBox
     django_manage:

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -49,3 +49,10 @@
       - "'REPORTS_ROOT' in netbox_config"
       - "'SCRIPTS_ROOT' in netbox_config"
     msg: "Please ensure MEDIA_ROOT/REPORTS_ROOT/SCRIPTS_ROOT are defined in netbox_config."
+
+- name: Script/Report module names should follow PEP8
+  assert:
+    that:
+      - "(netbox_scripts | map(attribute='name') | map('regex_search', '^[a-z][a-z0-9_]*$') | select('string') | list | length) == (netbox_scripts | length)"
+      - "(netbox_reports | map(attribute='name') | map('regex_search', '^[a-z][a-z0-9_]*$') | select('string') | list | length) == (netbox_reports | length)"
+    msg: "Please ensure that your script/report module names start with a lowercase letter and contain only lowercase letters, numbers, and underscores."

--- a/tests/group_vars/netbox
+++ b/tests/group_vars/netbox
@@ -11,6 +11,12 @@ netbox_config:
   NAPALM_ARGS:
     use_keys: true
     key_file: '/srv/netbox/.ssh/id_rsa'
+netbox_scripts:
+  - src: scripts/nothing.py
+    name: nothing
+netbox_reports:
+  - src: reports/nothing.py
+    name: nothing
 netbox_napalm_enabled: true
 netbox_superuser_password: netbox
 netbox_database: "netbox_{{ inventory_hostname_short }}"

--- a/tests/reports/nothing.py
+++ b/tests/reports/nothing.py
@@ -1,0 +1,8 @@
+from extras.reports import Report
+
+
+class NothingReport(Report):
+    description = "A report."
+
+    def test_nothing(self):
+        self.log_success("Success! Hm? What is, you ask? That's a secret.")

--- a/tests/scripts/nothing.py
+++ b/tests/scripts/nothing.py
@@ -1,0 +1,6 @@
+from extras.scripts import Script
+
+
+class Nothing(Script):
+    def run(self, data, commit=False):
+        return ""


### PR DESCRIPTION
This adds a `netbox_reports` role variable in similar function to `netbox_scripts` and adds validation for the module names (mainly so that they can be imported by NetBox correctly - although no syntax validation is done for the scripts themselves).

Closes #70.