### PR TITLE
chg: Added password setting for socket based db

### DIFF
--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -21,6 +21,9 @@ DATABASE = {
     'HOST':  '{{ netbox_database_host }}',
     'PORT': '{{ netbox_database_port }}',
 {% else %}
+    {% if netbox_database_password is defined %}
+    'PASSWORD': '{{ netbox_database_password }}',
+    {% endif %}
     'HOST': '{{ netbox_database_socket }}',
 {% endif %}
     'CONN_MAX_AGE': {{ netbox_database_conn_age }},


### PR DESCRIPTION
On some deployments it is desired to also have a password supplied
even when using a UNIX socket. Such deployments failed in the near past.
This commit implements a checks for such a condition and inserts the
setting if necessary.