### PR TITLE
NetBox 2.8 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -244,18 +244,20 @@ directory to `{{ netbox_config.SCRIPTS_ROOT }}/migrate_application.py` and
 
 [source,yaml]
 ----
-netbox_plugins: []
+netbox_pip_packages: []
 
 ## Example:
-netbox_plugins:
+netbox_pip_packages:
   - https://github.com/steffann/netbox-example-plugin.git
   - netbox-topology-views
 ----
 
-This is a list of plugins to install via `pip` within NetBox' virtualenv. You
-can specify any valid artifact that `pip` understands to install a plugin. Be
-sure to include plugin configurations within the `netbox_config` role variable.
-Read https://netbox.readthedocs.io/en/stable/plugins/[Plugins] for more info.
+This is a list of extra packages to install via `pip` within NetBox'
+virtualenv. You can specify any valid artifact that `pip` understands.
+
+If you list any plugins here, be sure to include the appropriate plugin
+configurations within the `netbox_config` role variable.  Read
+https://netbox.readthedocs.io/en/stable/plugins/[Plugins] for more info.
 
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -372,6 +372,21 @@ Toggle `netbox_install_epel` to `false` if you do not want this role to install
 the Fedora EPEL for you. This can be useful for enterprise environments where
 the system's repositories are managed/mirrored by the enterprise.
 
+[source,yaml]
+----
+netbox_packages: []
+netbox_python_packages: []
+netbox_python_binary: /usr/bin/python{{ some version }}
+netbox_ldap_packages: []
+----
+
+These variables are dynamically generated based on the target distribution. You
+can check the defaults for these underneath the `vars/` directory. You can use
+these variables to target an unsupported operating system (although feel free
+to open a PR to add in support!) or to specify a custom Python interpreter
+(such as PyPy) to be used for deployment. Although, please note that support by
+this role may be limited for alternative Python installations.
+
 == Example Playbook
 
 The following installs PostgreSQL and creates a user with @geerlingguy's robust

--- a/README.adoc
+++ b/README.adoc
@@ -174,7 +174,9 @@ netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
 netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
 ----
 
-This populates the `REDIS` config dictionary in `configuration.py`. Utilize the second set of variables if you wish to seperate your cache database from your webhooks database.
+This populates the `REDIS` config dictionary in `configuration.py`. Utilize the
+second set of variables if you wish to seperate your cache database from your
+webhooks database.
 
 [source,yaml]
 ----
@@ -227,6 +229,7 @@ to upload for use within NetBox. These should be lists of dictionaries with a
 
 [source,yaml]
 ----
+## Example
 netbox_scripts:
   - src: netbox_scripts/migrate_application.py
     name: migrate_application
@@ -285,8 +288,9 @@ netbox_requests_log: "file:{{ netbox_shared_path }}/requests.log"
 
 These define where logs will be stored. You can use external logging facilities
 instead of local files if you wish,
-http://uwsgi-docs.readthedocs.io/en/latest/Logging.html#pluggable-loggers[as long as uWSGI supports it].
-Application log correlates to `logger` and requests log to `req-logger`.
+http://uwsgi-docs.readthedocs.io/en/latest/Logging.html#pluggable-loggers[as
+long as uWSGI supports it].  Application log correlates to `logger` and
+requests log to `req-logger`.
 
 [source,yaml]
 netbox_load_initial_data: false
@@ -317,15 +321,24 @@ to be able to use NAPALM. Add extra NAPALM python libraries by listing them in
 `netbox_napalm_packages` (e.g. `napalm-eos`).
 
 [source,yaml]
-netbox_metrics_enabled: true
+netbox_metrics_enabled: false
 
-Toggle `netbox_metrics_enabled` to `true` to enable application metrics (via https://github.com/korfuri/django-prometheus[django-prometheus]). This adds relevant pieces of configuration for proper metrics handling. (https://netbox.readthedocs.io/en/stable/additional-features/prometheus-metrics/[more info]).
+Toggle `netbox_metrics_enabled` to `true` to enable application metrics (via
+https://github.com/korfuri/django-prometheus[django-prometheus]). This adds
+relevant pieces of configuration for proper metrics handling.
+(https://netbox.readthedocs.io/en/stable/additional-features/prometheus-metrics/[more
+info]).
 
 [source,yaml]
+----
 netbox_metrics_dir: netbox_metrics
 netbox_metrics_path: "/run/{{ netbox_metrics_dir }}"
+----
 
-The directory name where the metrics files are stored can be set with `netbox_metrics_dir`. However, `netbox_metrics_path` must remain the default (seen above) in order to work with `systemd` and the `RuntimeDirectory` parameter (which only points to `/run`).
+The directory name where the metrics files are stored can be set with
+`netbox_metrics_dir`. However, `netbox_metrics_path` must remain the default
+(seen above) in order to work with `systemd` and the `RuntimeDirectory`
+parameter (which only points to `/run`).
 
 [source,yaml]
 netbox_keep_uwsgi_updated: false

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :role-name: netbox
 :role: {role-author}.{role-name}
 :gh-name: {role-author}/ansible-role-{role-name}
-:netbox-version: 2.7.12
+:netbox-version: 2.8.1
 = {role}
 :toc:
 :toc-placement: preamble

--- a/README.adoc
+++ b/README.adoc
@@ -310,11 +310,6 @@ long as uWSGI supports it].  Application log correlates to `logger` and
 requests log to `req-logger`.
 
 [source,yaml]
-netbox_load_initial_data: false
-
-To load the initial data shipped by NetBox, set this to `true`.
-
-[source,yaml]
 ----
 netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2

--- a/README.adoc
+++ b/README.adoc
@@ -244,6 +244,21 @@ directory to `{{ netbox_config.SCRIPTS_ROOT }}/migrate_application.py` and
 
 [source,yaml]
 ----
+netbox_plugins: []
+
+## Example:
+netbox_plugins:
+  - https://github.com/steffann/netbox-example-plugin.git
+  - netbox-topology-views
+----
+
+This is a list of plugins to install via `pip` within NetBox' virtualenv. You
+can specify any valid artifact that `pip` understands to install a plugin. Be
+sure to include plugin configurations within the `netbox_config` role variable.
+Read https://netbox.readthedocs.io/en/stable/plugins/[Plugins] for more info.
+
+[source,yaml]
+----
 netbox_user: netbox
 netbox_group: netbox
 netbox_home: /srv/netbox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,6 @@ netbox_config:
 
 netbox_scripts: []
 netbox_reports: []
-netbox_plugins: []
 
 netbox_user: netbox
 netbox_group: netbox
@@ -80,6 +79,7 @@ netbox_napalm_enabled: false
 netbox_napalm_packages:
   - napalm
 
+netbox_pip_packages: []
 netbox_pip_constraints:
   # Blacklist pynacl 1.3.0 due to https://github.com/pyca/pynacl/issues/479
   - 'pynacl!=1.3.0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ netbox_config:
 
 netbox_scripts: []
 netbox_reports: []
+netbox_plugins: []
 
 netbox_user: netbox
 netbox_group: netbox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.7.12
+netbox_stable_version: 2.8.1
 netbox_stable_uri: "https://github.com/netbox-community/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,8 +70,6 @@ netbox_processes: "{{ ansible_processor_vcpus }}"
 netbox_application_log: "file:{{ netbox_shared_path }}/application.log"
 netbox_requests_log: "file:{{ netbox_shared_path }}/requests.log"
 
-netbox_load_initial_data: false
-
 netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -50,6 +50,8 @@
   until: _netbox_pip_additional_install is succeeded
   when: (_netbox_python_deps | length) > 0
   loop: "{{ _netbox_python_deps }}"
+  notify:
+    - restart netbox.service
 
 - name: Generate NetBox configuration file
   template:

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -142,14 +142,5 @@
       app_path: "{{ netbox_current_path }}/netbox"
       virtualenv: "{{ netbox_virtualenv_path }}"
 
-  - name: Populate NetBox with initial data
-    django_manage:
-      command: loaddata
-      fixtures: initial_data
-      app_path: "{{ netbox_current_path }}/netbox"
-      virtualenv: "{{ netbox_virtualenv_path }}"
-    when:
-      - netbox_load_initial_data
-
   become: True
   become_user: "{{ netbox_user }}"

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -34,7 +34,7 @@
       - "{{ 'django-auth-ldap' if netbox_ldap_enabled else [] }}"
       - "{{ 'django-storages' if _netbox_storages_module is defined else [] }}"
       - "{{ _netbox_storages_map[_netbox_storages_module] if _netbox_storages_module is defined else [] }}"
-      - "{{ netbox_plugins }}"
+      - "{{ netbox_pip_packages }}"
 
 - name: Flatten that list of dependencies
   set_fact:

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -34,6 +34,7 @@
       - "{{ 'django-auth-ldap' if netbox_ldap_enabled else [] }}"
       - "{{ 'django-storages' if _netbox_storages_module is defined else [] }}"
       - "{{ _netbox_storages_map[_netbox_storages_module] if _netbox_storages_module is defined else [] }}"
+      - "{{ netbox_plugins }}"
 
 - name: Flatten that list of dependencies
   set_fact:

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -51,7 +51,7 @@
     _path: "{{ _path_exec.stdout }}"
   check_mode: false
 
-- name: Capture Default Python Interpreter
+- name: Capture the current Python interpreter
   set_fact:
      _netbox_global_python: "{{ ansible_python_interpreter }}"
   when: ansible_python_interpreter is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,10 +21,13 @@
 - name: Ensure the installed Python version is newer than 3.6.0 for NetBox 2.8+
   assert:
     that:
-      - "ansible_python_version | version_compare('3.6.0', '>=')"
-    msg: "NetBox 2.8.0+ requires Python 3.6+. Please either specify an older NetBox version or upgrade to a newer distribution that provides Python 3.6+."
+      - "ansible_python_version is version('3.6.0', '>=')"
+    msg: >
+      NetBox 2.8.0+ requires Python 3.6+. Please either specify an older NetBox
+      version, upgrade to a newer distribution that provides Python 3.6+, or
+      set netbox_python_binary to an appropriate Python 3.6+ binary.
   when:
-    - (netbox_stable and netbox_stable_version | version_compare('2.8.0', '>=') or netbox_git
+    - netbox_stable and netbox_stable_version is version('2.8.0', '>=') or netbox_git
 
 - name: Create NetBox user group
   group:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,22 @@
   set_fact:
     ansible_python_interpreter: "{{ netbox_python_binary }}"
 
+- name: Recheck new Python interpreter's version
+  setup:
+    gather_subset: min
+    filter: ansible_python_version
+
+# Can't quite check the effective version of a git installation this early since
+# the repo isn't checked out, but most users will be on develop in the first
+# place so this dumb check should be good enough.
+- name: Ensure the installed Python version is newer than 3.6.0 for NetBox 2.8+
+  assert:
+    that:
+      - "ansible_python_version | version_compare('3.6.0', '>=')"
+    msg: "NetBox 2.8.0+ requires Python 3.6+. Please either specify an older NetBox version or upgrade to a newer distribution that provides Python 3.6+."
+  when:
+    - (netbox_stable and netbox_stable_version | version_compare('2.8.0', '>=') or netbox_git
+
 - name: Create NetBox user group
   group:
     name: "{{ netbox_group }}"
@@ -101,6 +117,11 @@
     state: started
     enabled: yes
 
-- name: Restore Default Python Interpreter
+- name: Restore the previous Ansible Python interpreter
   set_fact:
      ansible_python_interpreter: "{{ _netbox_global_python if _netbox_global_python is defined else 'auto_legacy' }}"
+
+- name: Recheck the previous Python interpreter's version
+  setup:
+    gather_subset: min
+    filter: ansible_python_version

--- a/tests/group_vars/netbox
+++ b/tests/group_vars/netbox
@@ -1,5 +1,7 @@
 ---
 netbox_socket: "0.0.0.0:8080"
+netbox_pip_packages:
+  - netbox-topology-views
 netbox_config:
   ALLOWED_HOSTS:
     - "{{ inventory_hostname }}"
@@ -11,6 +13,8 @@ netbox_config:
   NAPALM_ARGS:
     use_keys: true
     key_file: '/srv/netbox/.ssh/id_rsa'
+  PLUGINS:
+    - netbox_topology_views
 netbox_scripts:
   - src: scripts/nothing.py
     name: nothing


### PR DESCRIPTION
This introduces feature support for NetBox 2.8. If you can test this branch out by upgrading an existing installation (or copy of one), please do so and report back. Confirmations of successful upgrades will result in a quicker merge (as I'm having some test suite issues I need to resolve currently).

To deploy NetBox 2.8, use `ansible-galaxy` to install this branch:

```
ansible-galaxy install https://github.com/lae/ansible-role-netbox/archive/feature/netbox-2.8.tar.gz,v0.10.0-pre,lae.netbox --force
```

## Changes

If I'm missing anything, please leave a comment.
 
- Requirement conditions for Python 3.6+ (complete)
- Plugins/additional Python dependencies support (complete)

Also, I'm considering marking this release as 1.0, since it has generally been stable for a while now. Thoughts?