### PR TITLE
Fix ansible_python_interpreter

### DIFF
--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -50,3 +50,8 @@
   set_fact:
     _path: "{{ _path_exec.stdout }}"
   check_mode: false
+
+- name: Capture Default Python Interpreter
+  set_fact:
+     _netbox_global_python: "{{ ansible_python_interpreter }}"
+  when: ansible_python_interpreter is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,4 +104,3 @@
 - name: Restore Default Python Interpreter
   set_fact:
      ansible_python_interpreter: "{{ _netbox_global_python if _netbox_global_python is defined else 'auto_legacy' }}"
-  when: ansible_python_interpreter is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,3 +100,8 @@
     name: netbox-rqworker.service
     state: started
     enabled: yes
+
+- name: Restore Default Python Interpreter
+  set_fact:
+     ansible_python_interpreter: "{{ _netbox_global_python if _netbox_global_python is defined else 'auto_legacy' }}"
+  when: ansible_python_interpreter is defined


### PR DESCRIPTION
In the role's current format it sets `ansible_python_interpreter` to `netbox_python_binary` before executing any tasks, however it does not return it to the original value when the role completes. This can cause issues with subsequently executing modules such as yum, that require a python2 interpreter.

This can be resolved by the enduser by setting `ansible_python_interpreter` to the desired binary(assuming he knows it) after an `include_role` or `import_role` task before moving on to the next task/role but obviously this is not desirable. More importantly it does not solve for calling roles the old fashioned way such as this:

```
  roles: 
    - geerlingguy.postgresql
    - davidwittman.redis
    - lae.netbox
    - nginxinc.nginx
```

Capturing the initial value of `ansible_python_interpreter` on load and resetting it to something similar when we are done is the best way I can think of to deal with this, because you can't undefine a variable the best solution is to set it to the `auto_legacy` value as described here: https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html

One thing I didn't account for was if the role exits with an error the variable will not be reset, but I don't know why you would want to run subsequent tasks/roles after a failed install, so does it matter?