### PR TITLE
Update test suite to travis-lxc 0.9.0, remove ansible devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,35 @@ python:
   - "2.7"
   - "3.6"
 sudo: required
-dist: trusty
+dist: bionic
 cache:
   directories: [ '$HOME/lxc' ]
   pip: true
 services:
 - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 env:
-- ANSIBLE_GIT_VERSION='devel' # 2.9.x development branch
-- ANSIBLE_VERSION='<2.9.0' # 2.8.x
+- ANSIBLE_VERSION='~=2.9.0'
 matrix:
   fast_finish: true
+# FIXME: Ansible 2.10.x going through major restructuring.
+# https://groups.google.com/forum/#!msg/ansible-project/eXsoOKEd0Mk/XTgbnPWbCAAJ
+#  include:
+#    - python: '3.6'
+#      env: ANSIBLE_GIT_VERSION='devel' # 2.10.x development branch
 install:
 - if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
   else pip install "ansible${ANSIBLE_VERSION}"; fi;
   pip install --pre ansible-lint
 - ansible --version
-- ansible-galaxy install lae.travis-lxc
+- ansible-galaxy install lae.travis-lxc,v0.9.0
 - ansible-playbook tests/install.yml -i tests/inventory
 - git archive --format tar.gz HEAD > lae.netbox.tar.gz && ansible-galaxy install
   lae.netbox.tar.gz,$(git rev-parse HEAD),lae.netbox && rm lae.netbox.tar.gz
 before_script:
-- echo "host all all 10.0.3.0/24 trust" | sudo tee -a /etc/postgresql/9.4/main/pg_hba.conf
-- echo "listen_addresses = '*'" | sudo tee -a /etc/postgresql/9.4/main/postgresql.conf
+- echo "host all all 10.0.3.0/24 trust" | sudo tee -a /etc/postgresql/9.6/main/pg_hba.conf
+- echo "listen_addresses = '*'" | sudo tee -a /etc/postgresql/9.6/main/postgresql.conf
 - sudo service postgresql restart
 - sudo redis-server /etc/redis/redis.conf --bind 10.0.3.1 --protected-mode no --port 6379
 - cd tests/

--- a/tests/group_vars/netbox_stable_2_7
+++ b/tests/group_vars/netbox_stable_2_7
@@ -1,0 +1,3 @@
+---
+netbox_stable: true
+netbox_stable_version: 2.7.12

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,17 +1,20 @@
 [netbox:children]
 netbox_stable
+netbox_stable_2_7
 netbox_git
 
 [netbox_stable]
 debian-buster-stable
-debian-stretch-stable
 ubuntu-bionic-stable
-ubuntu-xenial-stable
 centos-7-stable
+
+# The following distributions don't have Python 3.6 in standard repos, so pin
+# them to the last supported stable NetBox release (2.7.12)
+[netbox_stable_2_7]
+debian-stretch-stable
+ubuntu-xenial-stable
 
 [netbox_git]
 debian-buster-git
-debian-stretch-git
 ubuntu-bionic-git
-ubuntu-xenial-git
 centos-7-git


### PR DESCRIPTION
Should fix most if not all of the build errors as of late.