### PR TITLE
Use 'private' variable for netbox_config (#66)

### DIFF
--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -8,16 +8,16 @@
   loop:
     - "{{ netbox_releases_path }}"
     - "{{ netbox_shared_path }}"
-    - "{{ netbox_config.MEDIA_ROOT }}"
-    - "{{ netbox_config.MEDIA_ROOT }}/image-attachments"
-    - "{{ netbox_config.REPORTS_ROOT }}"
-    - "{{ netbox_config.SCRIPTS_ROOT }}"
+    - "{{ _netbox_config.MEDIA_ROOT }}"
+    - "{{ _netbox_config.MEDIA_ROOT }}/image-attachments"
+    - "{{ _netbox_config.REPORTS_ROOT }}"
+    - "{{ _netbox_config.SCRIPTS_ROOT }}"
 
 - include_tasks: "install_via_{{ 'git' if netbox_git else 'stable' }}.yml"
 
 - import_tasks: generate_secret_key.yml
   when:
-    - netbox_config.SECRET_KEY is not defined
+    - _netbox_config.SECRET_KEY is not defined
 
 - name: Drop pip constraints file
   template:
@@ -102,7 +102,7 @@
 - name: Copy NetBox scripts into SCRIPTS_ROOT
   copy:
     src: "{{ item.src }}"
-    dest: "{{ netbox_config.SCRIPTS_ROOT }}/{{ item.name }}.py"
+    dest: "{{ _netbox_config.SCRIPTS_ROOT }}/{{ item.name }}.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
   loop: "{{ netbox_scripts }}"
@@ -110,7 +110,7 @@
 - name: Copy NetBox reports into REPORTS_ROOT
   copy:
     src: "{{ item.src }}"
-    dest: "{{ netbox_config.REPORTS_ROOT }}/{{ item.name }}.py"
+    dest: "{{ _netbox_config.REPORTS_ROOT }}/{{ item.name }}.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
   loop: "{{ netbox_reports }}"

--- a/tasks/generate_secret_key.yml
+++ b/tasks/generate_secret_key.yml
@@ -15,4 +15,4 @@
 
 - name: Set netbox_config.SECRET_KEY to generated SECRET_KEY
   set_fact:
-    netbox_config: "{{ netbox_config | combine({'SECRET_KEY': _netbox_secret_key_file['content'] | b64decode}) }}"
+    _netbox_config: "{{ _netbox_config | combine({'SECRET_KEY': _netbox_secret_key_file['content'] | b64decode}) }}"

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -27,6 +27,10 @@
     netbox_ldap_packages: "{{ _netbox_ldap_packages | list }}"
   when: netbox_ldap_packages is not defined
 
+- name: Define _netbox_config
+  set_fact:
+    _netbox_config: "{{ netbox_config }}"
+
 - name: Generate list of optional Python dependencies
   set_fact:
     _netbox_python_deps:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -59,7 +59,7 @@ REDIS = {
 METRICS_ENABLED = True
 {% endif %}
 
-{% for setting, value in netbox_config.items() %}
+{% for setting, value in _netbox_config.items() %}
 {% if value in [True, False] %}
 {{ setting }} = {{ 'True' if value else 'False' }}
 {% elif value is string or value is number %}

--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -8,8 +8,8 @@ processes={{ netbox_processes }}
 module=netbox.wsgi
 virtualenv={{ netbox_virtualenv_path }}
 chdir={{ netbox_current_path }}/netbox
-{% if netbox_config.BASE_PATH is defined %}
-{% set _base_path = netbox_config.BASE_PATH.strip('/') ~ '/' %}
+{% if _netbox_config.BASE_PATH is defined %}
+{% set _base_path = _netbox_config.BASE_PATH.strip('/') ~ '/' %}
 {% else %}
 {% set _base_path = '' %}
 {% endif %}


### PR DESCRIPTION
This works around the problem in #66 that if you use the (increasingly more
common) include_role pattern variables you set externally could appear
immutable to the role logic. Thus, using set_fact with a combine() to
add SECRET_KEY to netbox_config will not work as expected.

Introducing a new 'private' (and thus mutable) variable in
load_variables works around the problem and allows the include_role
pattern to work.