### PR TITLE
NetBox 2.9 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,6 +84,10 @@ install `redis-server` via a task in `pre_tasks` within your playbook or use a
 Redis installation role such as
 https://galaxy.ansible.com/davidwittman/redis[DavidWittman.redis].
 
+WARNING: NetBox v2.9.0+ require Redis 4.0 at the minimum. The role suggested
+above defaults to a 2.8 version, so make sure you specify a newer version in a
+role variable or deploy Redis 4.0+ another way.
+
 == Role Variables
 
 TIP: See `examples/` for some playbooks you could write for different scenarios.
@@ -417,6 +421,8 @@ socket to talk to the Postgres server with the default netbox database user.
       - name: "{{ netbox_database_user }}"
         role_attr_flags: CREATEDB,NOSUPERUSER
     redis_bind: 127.0.0.1
+    redis_version: 6.0.9
+    redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
 ----
 
 Note the `CREATEDB` attribute.
@@ -448,6 +454,8 @@ installing NetBox on to authenticate with it over TCP:
     netbox_database_user: netbox_prod_user
     netbox_database_password: "very_secure_password_for_prod"
     redis_bind: 127.0.0.1
+    redis_version: 6.0.9
+    redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
 ----
 
 See the `examples/` directory for more.

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :role-name: netbox
 :role: {role-author}.{role-name}
 :gh-name: {role-author}/ansible-role-{role-name}
-:netbox-version: 2.8.6
+:netbox-version: 2.9.8
 = {role}
 :toc:
 :toc-placement: preamble

--- a/README.adoc
+++ b/README.adoc
@@ -318,7 +318,8 @@ netbox_ldap_config_template: netbox_ldap_config.py.j2
 Toggle `netbox_ldap_enabled` to `true` to configure LDAP authentication for
 NetBox. `netbox_ldap_config_template` should be the path to your template - by
 default, Ansible will search your playbook's `templates/` directory for this.
-You can find an example in `examples/`.
+You can find an example in `examples/`. You will also need to set
+`netbox_config.REMOTE_AUTH_BACKEND` to `netbox.authentication.LDAPBackend`.
 
 [source,yaml]
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.8.6
+netbox_stable_version: 2.9.8
 netbox_stable_uri: "https://github.com/netbox-community/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false

--- a/examples/playbook_single_host_deploy.yml
+++ b/examples/playbook_single_host_deploy.yml
@@ -24,6 +24,8 @@
       - name: "{{ netbox_database_user }}"
         role_attr_flags: CREATEDB,NOSUPERUSER
     redis_bind: 127.0.0.1
+    redis_version: 6.0.9
+    redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
   pre_tasks:
     - name: Enable Subscription Manager Repos
       rhsm_repository:

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -33,6 +33,15 @@
   changed_when: False
   failed_when: "_netbox_git_contains_tasks_rename.rc not in [0, 1]"
 
+- name: Check existence of commit 90dbe9b, renaming DEFAULT_TIMEOUT to RQ_DEFAULT_TIMEOUT
+  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^90dbe9bf60ab3c72be10fd070c65c26dca543ca5'
+  args:
+    chdir: "{{ netbox_git_repo_path }}"
+    executable: /bin/bash
+  register: _netbox_git_contains_rq_timeout
+  changed_when: False
+  failed_when: "_netbox_git_contains_rq_timeout.rc not in [0, 1]"
+
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -30,6 +30,13 @@ DATABASE = {
     'CONN_MAX_AGE': {{ netbox_database_conn_age }},
 }
 
+{% if netbox_stable and netbox_stable_version is version('2.9.4', '>=') or
+      netbox_git and _netbox_git_contains_rq_timeout.rc == 0 %}
+{% set _default_timeout = "RQ_DEFAULT_TIMEOUT" %}
+{% else %}
+{% set _default_timeout = "DEFAULT_TIMEOUT" %}
+{% endif %}
+
 REDIS = {
 {# https://github.com/netbox-community/netbox/pull/4366 #}
 {% if netbox_stable and netbox_stable_version is version('2.7.11', '>=') or
@@ -42,7 +49,7 @@ REDIS = {
         'PORT': {{ netbox_redis_port }},
         'PASSWORD': '{{ netbox_redis_password }}',
         'DATABASE': {{ netbox_redis_database }},
-        'RQ_DEFAULT_TIMEOUT': {{ netbox_redis_default_timeout }},
+        '{{ _default_timeout }}': {{ netbox_redis_default_timeout }},
         'SSL': {{ netbox_redis_ssl_enabled }},
     },
     'caching': {
@@ -50,7 +57,7 @@ REDIS = {
         'PORT': {{ netbox_redis_cache_port }},
         'PASSWORD': '{{ netbox_redis_cache_password }}',
         'DATABASE': {{ netbox_redis_cache_database }},
-        'RQ_DEFAULT_TIMEOUT': {{ netbox_redis_cache_default_timeout }},
+        '{{ _default_timeout }}': {{ netbox_redis_default_timeout }},
         'SSL': {{ netbox_redis_cache_ssl_enabled }},
     }
 }

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -22,9 +22,9 @@ DATABASE = {
     'HOST':  '{{ netbox_database_host }}',
     'PORT': '{{ netbox_database_port }}',
 {% else %}
-    {% if netbox_database_password is defined %}
+{%      if netbox_database_password is defined %}
     'PASSWORD': '{{ netbox_database_password }}',
-    {% endif %}
+{%      endif %}
     'HOST': '{{ netbox_database_socket }}',
 {% endif %}
     'CONN_MAX_AGE': {{ netbox_database_conn_age }},
@@ -67,13 +67,13 @@ METRICS_ENABLED = True
 {% endif %}
 
 {% for setting, value in _netbox_config.items() %}
-{% if value in [True, False] %}
+{%      if value in [True, False] %}
 {{ setting }} = {{ 'True' if value else 'False' }}
-{% elif value is string or value is number %}
+{%      elif value is string or value is number %}
 {{ setting }} = {{ value | to_nice_json }}
-{% else %}
+{%      else %}
 {{ setting }} = json.loads(r'''{{ value | to_json }}''')
-{% endif %}
+{%      endif %}
 {% endfor %}
 
 # vim: ft=python

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -40,7 +40,7 @@ DATABASE = {
 REDIS = {
 {# https://github.com/netbox-community/netbox/pull/4366 #}
 {% if netbox_stable and netbox_stable_version is version('2.7.11', '>=') or
-      netbox_git and _netbox_git_contains_tasks_rename %}
+      netbox_git and _netbox_git_contains_tasks_rename.rc == 0 %}
     'tasks': {
 {% else %}
     'webhooks': {


### PR DESCRIPTION
This introduces feature support for NetBox 2.9. If you can test this branch out by upgrading an existing installation (or copy of one), please do so and report back. Confirmations of successful upgrades will result in a quicker merge (as I'm having some test suite issues I need to resolve currently).

To deploy NetBox 2.9, use `ansible-galaxy` to install this branch:

```
ansible-galaxy install https://github.com/lae/ansible-role-netbox/archive/feature/netbox-2.9.tar.gz,v1.1.0-pre,lae.netbox --force
```

## Changes

Not very many significant ones as far as I can tell. If I'm missing anything, please leave a comment.

* `RQ_DEFAULT_TIMEOUT` under redis config ([2.9.4 changelog](https://github.com/netbox-community/netbox/blob/develop/docs/release-notes/version-2.9.md#v294-2020-09-23))

Closes #112