### PR TITLE
Fixed deprecation warning when installing multiple pip with "with_items"

### DIFF
--- a/tasks/install_packages_yum.yml
+++ b/tasks/install_packages_yum.yml
@@ -27,12 +27,11 @@
 # python3 psycopg2/selinux packages are not available on EPEL.
 - name: Install psycopg2/selinux via pip on Red Hat-based distros
   pip:
-    name: "{{ item }}"
+    name:
+      - psycopg2-binary
+      - selinux
     state: present
   vars:
     ansible_python_interpreter: "{{ netbox_python_binary }}"
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
-  with_items:
-    - psycopg2-binary
-    - selinux


### PR DESCRIPTION
The below deprecation warning comes at task 'Install psycopg2/selinux via pip on Red Hat-based distros':
'Invoking "pip" only once while using a loop via squash_actions is deprecated.'
Also there was a small problem when systemd units are being started: the daemon_reload was missing.