### PR TITLE
Netbox 2.10 needs manage.py trace_paths run on upgrade

### DIFF
--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -122,6 +122,12 @@
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
 
+    - name: Trace missing cable paths for NetBox
+      django_manage:
+        command: "trace_paths --no-input"
+        app_path: "{{ netbox_current_path }}/netbox"
+        virtualenv: "{{ netbox_virtualenv_path }}"
+
     - name: Create a super user for NetBox
       shell: "printf '{{ netbox_superuser_script }}' |\
               {{ netbox_virtualenv_path }}/bin/python {{ netbox_current_path }}/netbox/manage.py shell"
@@ -141,6 +147,19 @@
         command: clearsessions
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
+
+    - name: Clear stale content types in NetBox
+      django_manage:
+        command: "remove_stale_contenttypes --no-input"
+        app_path: "{{ netbox_current_path }}/netbox"
+        virtualenv: "{{ netbox_virtualenv_path }}"
+
+    - name: Clear cached data in NetBox
+      django_manage:
+        command: "invalidate all"
+        app_path: "{{ netbox_current_path }}/netbox"
+        virtualenv: "{{ netbox_virtualenv_path }}"
+
 
   become: true
   become_user: "{{ netbox_user }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -127,6 +127,7 @@
         command: "trace_paths --no-input"
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
+      when: "netbox_stable_version is version('2.10.0', '>=')"
 
     - name: Create a super user for NetBox
       shell: "printf '{{ netbox_superuser_script }}' |\


### PR DESCRIPTION
Looking at the upgrade.sh for Netbox 2.10 it needs to run manage.py trace_paths --no-input once to populate the new dcim_cablepath table, the manage.py migrate step doesn't do it.  In addition there are a couple of other commands in the update script to invalidate caches that probably make sense to run on updates. 