### PR TITLE
NetBox 2.10 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :role-name: netbox
 :role: {role-author}.{role-name}
 :gh-name: {role-author}/ansible-role-{role-name}
-:netbox-version: 2.9.9
+:netbox-version: 2.10.10
 = {role}
 :toc:
 :toc-placement: preamble
@@ -189,6 +189,7 @@ netbox_redis_password: ''
 netbox_redis_database: 0
 netbox_redis_default_timeout: 300
 netbox_redis_ssl_enabled: false
+netbox_redis_insecure_skip_tls_verify: false
 
 netbox_redis_cache_host: "{{ netbox_redis_host }}"
 netbox_redis_cache_port: "{{ netbox_redis_port }}"
@@ -196,6 +197,7 @@ netbox_redis_cache_database: 1
 netbox_redis_cache_password: "{{ netbox_redis_password }}"
 netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
 netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
+netbox_redis_cache_insecure_skip_tls_verify: "{{ netbox_redis_insecure_skip_tls_verify }}"
 ----
 
 This populates the `REDIS` config dictionary in `configuration.py`. Use the

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,15 @@ Vagrant.configure("2") do |config|
   config.vm.box = "debian/buster64"
   config.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "examples/playbook_single_host_deploy.yml"
+  config.vm.provision :ansible do |ansible|
+    ansible.limit = "all,localhost"
+    ansible.playbook = "tests/vagrant/package_role.yml"
+    ansible.verbose = true
+  end
+
+  config.vm.provision :ansible do |ansible|
+    ansible.limit = "all"
+    ansible.playbook = "tests/vagrant/provision.yml"
+    ansible.verbose = true
   end
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.9.9
+netbox_stable_version: 2.10.10
 netbox_stable_uri: "https://github.com/netbox-community/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false
@@ -33,6 +33,7 @@ netbox_redis_password: ''
 netbox_redis_database: 0
 netbox_redis_default_timeout: 300
 netbox_redis_ssl_enabled: false
+netbox_redis_insecure_skip_tls_verify: false
 
 netbox_redis_cache_host: "{{ netbox_redis_host }}"
 netbox_redis_cache_sentinels: "{{ netbox_redis_sentinels }}"
@@ -42,6 +43,7 @@ netbox_redis_cache_database: 1
 netbox_redis_cache_password: "{{ netbox_redis_password }}"
 netbox_redis_cache_default_timeout: "{{ netbox_redis_default_timeout }}"
 netbox_redis_cache_ssl_enabled: "{{ netbox_redis_ssl_enabled }}"
+netbox_redis_cache_insecure_skip_tls_verify: "{{ netbox_redis_insecure_skip_tls_verify }}"
 
 netbox_metrics_enabled: false
 netbox_metrics_dir: netbox_metrics

--- a/examples/netbox_config.yml
+++ b/examples/netbox_config.yml
@@ -63,6 +63,7 @@ netbox_config:
   LOGIN_REQUIRED: true
   LOGIN_TIMEOUT: 1209600
   MAINTENANCE_MODE: false
+  MAPS_URL: https://maps.google.com/?q=
   MAX_PAGE_SIZE: 500
   MEDIA_ROOT: /srv/netbox_media
   METRICS_ENABLED: true

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -121,6 +121,9 @@
         command: migrate
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
+      retries: 2
+      register: _netbox_db_migration
+      until: _netbox_db_migration is success
 
     - name: Trace missing cable paths for NetBox
       django_manage:

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -127,7 +127,9 @@
         command: "trace_paths --no-input"
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
-      when: "netbox_stable_version is version('2.10.0', '>=')"
+      when:
+        - netbox_stable and netbox_stable_version is version('2.10.0', '>=')
+          or netbox_git and _netbox_git_contains_trace_paths.rc == 0
 
     - name: Create a super user for NetBox
       shell: "printf '{{ netbox_superuser_script }}' |\

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -42,6 +42,15 @@
   changed_when: False
   failed_when: "_netbox_git_contains_rq_timeout.rc not in [0, 1]"
 
+- name: Check existence of commit f560693, introducing trace_paths management command
+  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^f560693748d1f35e79ad9d006a8a9b75ef5ae37b'
+  args:
+    chdir: "{{ netbox_git_repo_path }}"
+    executable: /bin/bash
+  register: _netbox_git_contains_trace_paths
+  changed_when: False
+  failed_when: "_netbox_git_contains_trace_paths.rc not in [0, 1]"
+
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -70,6 +70,7 @@ REDIS = {
         'PASSWORD': '{{ netbox_redis_password }}',
         'DATABASE': {{ netbox_redis_database }},
         'SSL': {{ netbox_redis_ssl_enabled }},
+        'INSECURE_SKIP_TLS_VERIFY': {{ netbox_redis_insecure_skip_tls_verify }},
     },
     'caching': {
 {% if netbox_redis_cache_sentinels|length == 0 %}
@@ -88,6 +89,7 @@ REDIS = {
         'PASSWORD': '{{ netbox_redis_cache_password }}',
         'DATABASE': {{ netbox_redis_cache_database }},
         'SSL': {{ netbox_redis_cache_ssl_enabled }},
+        'INSECURE_SKIP_TLS_VERIFY': {{ netbox_redis_cache_insecure_skip_tls_verify }},
     }
 }
 

--- a/tests/group_vars/netbox_git
+++ b/tests/group_vars/netbox_git
@@ -1,2 +1,3 @@
 ---
 netbox_git: true
+netbox_git_version: develop-2.10

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -6,10 +6,7 @@
   vars:
     test_profiles:
       - profile: debian-buster
-      - profile: debian-stretch
       - profile: ubuntu-bionic
-      - profile: ubuntu-xenial
       - profile: centos-7
     test_host_suffixes:
-      - stable
       - git

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,18 +1,5 @@
 [netbox:children]
-netbox_stable
-netbox_stable_2_7
 netbox_git
-
-[netbox_stable]
-debian-buster-stable
-ubuntu-bionic-stable
-centos-7-stable
-
-# The following distributions don't have Python 3.6 in standard repos, so pin
-# them to the last supported stable NetBox release (2.7.12)
-[netbox_stable_2_7]
-debian-stretch-stable
-ubuntu-xenial-stable
 
 [netbox_git]
 debian-buster-git

--- a/tests/vagrant/group_vars/all
+++ b/tests/vagrant/group_vars/all
@@ -1,0 +1,24 @@
+---
+ansible_python_interpreter: /usr/bin/python3
+
+netbox_stable: true
+netbox_socket: "0.0.0.0:80"
+netbox_superuser_password: netbox
+netbox_config:
+  ALLOWED_HOSTS:
+    - "{{ inventory_hostname }}"
+    # The following should not be used in production, probably.
+    # This playbook gets used by Vagrant where we don't know the actual hostname.
+    - "*"
+  MEDIA_ROOT: "{{ netbox_shared_path }}/media"
+  REPORTS_ROOT: "{{ netbox_shared_path }}/reports"
+  SCRIPTS_ROOT: "{{ netbox_shared_path }}/scripts"
+netbox_database_socket: "{{ postgresql_unix_socket_directories[0] }}"
+netbox_keep_uwsgi_updated: true
+postgres_users_no_log: False
+postgresql_users:
+  - name: "{{ netbox_database_user }}"
+    role_attr_flags: CREATEDB,NOSUPERUSER
+redis_bind: 127.0.0.1
+redis_version: 6.0.9
+redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd

--- a/tests/vagrant/package_role.yml
+++ b/tests/vagrant/package_role.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    role_name: lae.netbox
+  tasks:
+    - block:
+        - shell: pwd
+        - name: Package up current working role
+          shell: "cd $(git rev-parse --show-toplevel); git ls-files -z | xargs -0 tar -czvf $OLDPWD/{{ role_name }}.tar.gz"
+        - name: Install packaged role
+          shell: "ansible-galaxy install {{ role_name }}.tar.gz,devel-$(git rev-parse HEAD),{{ role_name }} --force"
+        - name: Remove packaged role artifact
+          file:
+            dest: "{{ role_name }}.tar.gz"
+            state: absent

--- a/tests/vagrant/provision.yml
+++ b/tests/vagrant/provision.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  become: True
+  pre_tasks:
+    - name: Copy apt proxy detection script
+      ansible.builtin.template:
+        src: detect-http-proxy.j2
+        dest: /etc/apt/detect-http-proxy
+        mode: 0755
+    - name: Configure apt to use detection script
+      ansible.builtin.copy:
+        content: "Acquire::Retries 0;\nAcquire::http::ProxyAutoDetect \"/etc/apt/detect-http-proxy\";"
+        dest: /etc/apt/apt.conf.d/30detectproxy
+  roles:
+    - geerlingguy.postgresql
+    - davidwittman.redis
+    - lae.netbox

--- a/tests/vagrant/templates/detect-http-proxy.j2
+++ b/tests/vagrant/templates/detect-http-proxy.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+APT_CACHE_HOST="{{ lookup('env', 'APT_CACHE_HOST') }}"
+
+# Check if we can connect to the given host and provide it if so
+if [ ! -z "${APT_CACHE_HOST}" ]; then
+    if $(nc -zw1 "${APT_CACHE_HOST}" 3142); then
+        echo "http://${APT_CACHE_HOST}:3142"
+        exit
+    fi
+fi
+
+# Otherwise, don't use a proxy
+echo "DIRECT"


### PR DESCRIPTION
This introduces feature support for NetBox 2.10.

## Changes

* `INSECURE_SKIP_TLS_VERIFY` under redis config ([2.10.9 changelog](https://github.com/netbox-community/netbox/releases/tag/v2.10.9))
* trace_paths management command ([2.10.0 changelog](https://github.com/netbox-community/netbox/releases/tag/v2.10.0))
* Vagrant playbook updates since CI isn't working for now