### PR TITLE
Debian 11 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ IP address management (IPAM) and data center infrastructure management (DCIM) to
 This role will deploy NetBox within its own virtualenv either by release
 tarball or via git using uWSGI as the application server.
 
-Tested and supported against CentOS 7/Debian 9 and 10/Ubuntu 16, 18 and 20.
+Tested and supported against CentOS 7 / Debian 9,10,11 / Ubuntu 16, 18 and 20.
 
 Note that this role is slightly opinionated and differs from installation
 instructions from the NetBox documentation. The main differences are:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
       versions:
         - buster
         - stretch
+        - bullseye
     - name: EL
       versions:
         - 7

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,0 +1,19 @@
+---
+_netbox_packages:
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libjpeg-dev
+  - graphviz
+  - libpq-dev
+  - libssl-dev
+_netbox_python_packages:
+  - python3.9
+  - python3.9-dev
+  - python3-venv
+  - python3-pip
+  - python3-psycopg2  # used by ansible's postgres modules
+_netbox_python_binary: /usr/bin/python3
+_netbox_ldap_packages:
+  - libldap2-dev
+  - libsasl2-dev


### PR DESCRIPTION
This pull requests adds the neccessary variables file for running the role on Debian 11 ("bullseye") machines. The only change, in comparison to Debian 10, is the version of the Python interpreter.