### PR TITLE
Netbox 3.0 release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for lae.netbox
 netbox_stable: false
-netbox_stable_version: 2.10.10
+netbox_stable_version: 3.0.12
 netbox_stable_uri: "https://github.com/netbox-community/netbox/archive/v{{ netbox_stable_version }}.tar.gz"
 
 netbox_git: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,9 @@ netbox_pip_constraints:
   # Blacklist django-rq 2.3.1 due to https://github.com/rq/django-rq/issues/421
   # https://github.com/netbox-community/netbox/issues/4633
   - 'django-rq!=2.3.1'
+  # If you're using Netbox 2.11.3 or below, uncomment the below to fix database
+  # migrations. https://github.com/pallets/markupsafe/issues/284
+  # - 'MarkupSafe<2.1.0'
 
 netbox_keep_uwsgi_updated: false
 netbox_uwsgi_options: {}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,3 +22,8 @@
     name: netbox-rqworker.service
     state: restarted
     daemon_reload: true
+
+- name: reload netbox-rqworker.service
+  systemd:
+    name: netbox-rqworker.service
+    state: reloaded

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -6,6 +6,7 @@
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
   loop:
+    - "{{ netbox_home }}"
     - "{{ netbox_releases_path }}"
     - "{{ netbox_shared_path }}"
     - "{{ _netbox_config.MEDIA_ROOT }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -133,7 +133,7 @@
 
 - name: Schedule daily housekeeping cronjob
   cron:
-    name: "Schedule daily housekeeping cronjob"
+    name: "Netbox housekeeping"
     special_time: daily
     job: "{{ netbox_virtualenv_path }}/bin/python {{ netbox_current_path }}/netbox/manage.py housekeeping"
     user: "{{ netbox_user }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -27,12 +27,25 @@
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
 
-- name: Create NetBox virtualenv and install needed Python dependencies
+- name: Create NetBox virtualenv
+  pip:
+    name:
+      - pip
+      - setuptools
+    state: latest
+    virtualenv: "{{ netbox_virtualenv_path }}"
+    virtualenv_command: "{{ netbox_python_binary }} -m venv"
+  become: true
+  become_user: "{{ netbox_user }}"
+  retries: 2
+  register: _netbox_virtualenv_setup
+  until: _netbox_virtualenv_setup is succeeded
+
+- name: Install needed Python dependencies
   pip:
     requirements: "{{ netbox_current_path }}/requirements.txt"
     extra_args: "-c {{ netbox_current_path }}/constraints.txt"
     virtualenv: "{{ netbox_virtualenv_path }}"
-    virtualenv_command: "{{ netbox_python_binary }} -m venv"
   become: true
   become_user: "{{ netbox_user }}"
   retries: 2

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -115,6 +115,17 @@
     group: "{{ netbox_group }}"
   loop: "{{ netbox_reports }}"
 
+- name: Schedule daily housekeeping cronjob
+  cron:
+    name: "Schedule daily housekeeping cronjob"
+    special_time: daily
+    job: "{{ netbox_virtualenv_path }}/bin/python {{ netbox_current_path }}/netbox/manage.py housekeeping"
+    user: "{{ netbox_user }}"
+    cron_file: "netbox"
+  when:
+    - netbox_stable and netbox_stable_version is version('3.0.0', '>=')
+      or netbox_git and _netbox_git_contains_housekeeping.rc == 0
+
 - block:
     - name: Run database migrations for NetBox
       django_manage:

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -52,6 +52,7 @@
   loop: "{{ _netbox_python_deps }}"
   notify:
     - restart netbox.service
+    - restart netbox-rqworker.service
 
 - name: Generate NetBox configuration file
   template:
@@ -65,6 +66,7 @@
                py_compile.compile(f, c); os.remove(c)\""
   notify:
     - reload netbox.service
+    - reload netbox-rqworker.service
 
 - name: Generate LDAP configuration for NetBox if enabled
   template:
@@ -185,6 +187,9 @@
         command: "invalidate all"
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
+      when:
+        - netbox_stable and netbox_stable_version is version('3.0.0', '<')
+          or netbox_git and _netbox_git_contains_invalidate_removed.rc == 0
 
 
   become: true

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -51,6 +51,15 @@
   changed_when: False
   failed_when: "_netbox_git_contains_trace_paths.rc not in [0, 1]"
 
+- name: Check existence of commit d87ec82, introducing nightly housekeeping command
+  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^d87ec82fe34d92a84ee6f2a97ba0a87a53eed015'
+  args:
+    chdir: "{{ netbox_git_repo_path }}"
+    executable: /bin/bash
+  register: _netbox_git_contains_housekeeping
+  changed_when: False
+  failed_when: "_netbox_git_contains_housekeeping.rc not in [0, 1]"
+
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -60,6 +60,15 @@
   changed_when: False
   failed_when: "_netbox_git_contains_housekeeping.rc not in [0, 1]"
 
+- name: Check existence of commit 028c876, removing the invalidate command
+  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^028c876bcafbaede2731f191512bbebe3f1b6a9e'
+  args:
+    chdir: "{{ netbox_git_repo_path }}"
+    executable: /bin/bash
+  register: _netbox_git_contains_invalidate_removed
+  changed_when: False
+  failed_when: "_netbox_git_contains_invalidate_removed.rc not in [0, 1]"
+
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,16 +18,18 @@
 # Can't quite check the effective version of a git installation this early since
 # the repo isn't checked out, but most users will be on develop in the first
 # place so this dumb check should be good enough.
-- name: Ensure the installed Python version is newer than 3.6.0 for NetBox 2.8+
+- name: Ensure Python version installed is compatible with this version of Netbox
   assert:
     that:
-      - "ansible_python_version is version('3.6.0', '>=')"
+      - "ansible_python_version is version(item.python_needed, '>=')"
     msg: >
-      NetBox 2.8.0+ requires Python 3.6+. Please either specify an older NetBox
-      version, upgrade to a newer distribution that provides Python 3.6+, or
-      set netbox_python_binary to an appropriate Python 3.6+ binary.
+      NetBox {{ item.netbox_version_min }} requires at least Python {{ item.python_needed }}.
+      Please either specify an older NetBox version, upgrade to a newer
+      distribution that provides Python at least {{ item.python_needed }}, or
+      set netbox_python_binary to an appropriate Python {{ item.python_needed }} binary.
   when:
-    - netbox_stable and netbox_stable_version is version('2.8.0', '>=') or netbox_git
+    - netbox_stable and netbox_stable_version is version(item.netbox_version_min, '>=') or netbox_git
+  loop: "{{ netbox_python_compat_matrix }}"
 
 - name: Create NetBox user group
   group:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,3 +39,7 @@ netbox_superuser_token: |
         token = Token.objects.create(user=user)
         print("api-token: " + token.key)
         print("changed")
+
+netbox_python_compat_matrix:
+  - { netbox_version_min: '2.8.0', python_needed: '3.6.0' }
+  - { netbox_version_min: '3.0.0', python_needed: '3.7.0' }


### PR DESCRIPTION
Fix #132 

Add tasks to support installation of Netbox 3.0:
* Use latest pip/setuptools in virtualenv => create first the virtualenv with latest pip/setuptools before installing other dependencies
* Change permissions on netbox home => when installing pip libraries the `{{ netbox_home }}/.cache` will be used so `{{ netbox_home }}` need to be owned by netbox user
* Update for Netbox **3.0** => some tasks has been marked only for netbox <= 3.0 / include https://github.com/lae/ansible-role-netbox/pull/139
* Setup housekeeping (https://github.com/lae/ansible-role-netbox/pull/134)

Some ideas/information were retrieved from:
* https://github.com/lae/ansible-role-netbox/pull/136
* https://github.com/lae/ansible-role-netbox/issues/132