### PR TITLE
Allow optional install of uwsgi into Netbox venv, and v3.2 version constraint

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -419,6 +419,15 @@ Specify extra configuration options to insert into `uwsgi.ini` here. This is
 expected to be a dictionary of key/value pairs, e.g. `buffer-size: 65535`.
 
 [source,yaml]
+netbox_uwsgi_in_venv: false
+
+Toggle `netbox_uwsgi_in_venv` to `true` if you want `uwsgi` to be installed in the same virtual environment as NetBox.
+Otherwise, it will be installed system-wide into the library path of the python version used to created the virtual environment (normal/legacy behavior).
+
+WARNING: There's a possibility that this may become the default in a later version of this role (I think after further cross-platform testing).
+See https://github.com/lae/ansible-role-netbox/issues/144[issue #144] for further details.
+
+[source,yaml]
 netbox_install_epel: true
 
 Toggle `netbox_install_epel` to `false` if you do not want this role to install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,4 +98,5 @@ netbox_pip_constraints:
   # - 'MarkupSafe<2.1.0'
 
 netbox_keep_uwsgi_updated: false
+netbox_uwsgi_in_venv: false
 netbox_uwsgi_options: {}

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -59,3 +59,8 @@
   set_fact:
     _netbox_global_python: "{{ ansible_python_interpreter }}"
   when: ansible_python_interpreter is defined
+
+- name: Set the execution uwsgi command
+  set_fact:
+    netbox_uwsgi_cmd: "/usr/bin/env uwsgi"
+  when: "not netbox_uwsgi_in_venv | bool"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,7 @@
     name: uwsgi
     state: "{{ 'latest' if netbox_keep_uwsgi_updated else 'present' }}"
     umask: "0022"
+    virtualenv: "{{ omit if not netbox_uwsgi_in_venv else netbox_virtualenv_path }}"
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
   notify:

--- a/templates/netbox.service.j2
+++ b/templates/netbox.service.j2
@@ -6,7 +6,7 @@ Requires=netbox.socket
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/env uwsgi --ini {{ netbox_shared_path }}/uwsgi.ini
+ExecStart={{ netbox_uwsgi_cmd }} --ini {{ netbox_shared_path }}/uwsgi.ini
 ExecReload=/bin/kill -1 $MAINPID
 ExecStop=/bin/kill -2 $MAINPID
 StandardInput=socket

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 # vars file for lae.netbox
 netbox_config_path: "{{ netbox_current_path }}/netbox/netbox"
 netbox_virtualenv_path: "{{ netbox_current_path }}/venv-py3"
+netbox_uwsgi_cmd: "{{ netbox_virtualenv_path }}/bin/uwsgi"
 
 _netbox_storages_map:
   s3boto3: boto3
@@ -43,3 +44,4 @@ netbox_superuser_token: |
 netbox_python_compat_matrix:
   - { netbox_version_min: '2.8.0', python_needed: '3.6.0' }
   - { netbox_version_min: '3.0.0', python_needed: '3.7.0' }
+  - { netbox_version_min: '3.2.0', python_needed: '3.8.0' }


### PR DESCRIPTION
Fixes #144 

Also added a new version constraint for NetBox v3.2 requiring Python 3.8