### PR TITLE
Compatibility with Debian 12

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
     name: uwsgi
     state: "{{ 'latest' if netbox_keep_uwsgi_updated else 'present' }}"
     umask: "0022"
+    extra_args: "{{ (ansible_distribution_release == 'bookworm') | ternary('--break-system-packages', '') }}"
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
   notify:

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,0 +1,20 @@
+---
+_netbox_packages:
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libjpeg-dev
+  - graphviz
+  - libpq-dev
+  - libssl-dev
+  - systemd-cron
+_netbox_python_packages:
+  - python3.11
+  - python3.11-dev
+  - python3-venv
+  - python3-pip
+  - python3-psycopg2  # used by ansible's postgres modules
+_netbox_python_binary: /usr/bin/python3
+_netbox_ldap_packages:
+  - libldap2-dev
+  - libsasl2-dev


### PR DESCRIPTION
The newer Python on Debian 12 requires the use of the `--break-system-packages` pip flag to install packages globally.

Debian 12 also does not ship with a cron implementation anymore, so the `systemd-cron` compatibility package needs to be installed.