### PR TITLE
Compatibility with Debian 12, venv-based

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
     name: uwsgi
     state: "{{ 'latest' if netbox_keep_uwsgi_updated else 'present' }}"
     umask: "0022"
+    extra_args: "{{ (ansible_distribution_release == 'bookworm') | ternary('--break-system-packages', '') }}"
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,6 @@
     name: uwsgi
     state: "{{ 'latest' if netbox_keep_uwsgi_updated else 'present' }}"
     umask: "0022"
-    extra_args: "{{ (ansible_distribution_release == 'bookworm') | ternary('--break-system-packages', '') }}"
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
   notify:

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -18,3 +18,4 @@ _netbox_python_binary: /usr/bin/python3
 _netbox_ldap_packages:
   - libldap2-dev
   - libsasl2-dev
+netbox_uwsgi_in_venv: true

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,0 +1,20 @@
+---
+_netbox_packages:
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libjpeg-dev
+  - graphviz
+  - libpq-dev
+  - libssl-dev
+  - systemd-cron
+_netbox_python_packages:
+  - python3.11
+  - python3.11-dev
+  - python3-venv
+  - python3-pip
+  - python3-psycopg2  # used by ansible's postgres modules
+_netbox_python_binary: /usr/bin/python3
+_netbox_ldap_packages:
+  - libldap2-dev
+  - libsasl2-dev


### PR DESCRIPTION
Based on @davidmehren's [PR #162](https://github.com/lae/ansible-role-netbox/pull/162), but implementing @lae's [suggestion](https://github.com/lae/ansible-role-netbox/pull/162#issuecomment-1750519004) to install uWSGI in a venv instead of using `--break-system-packages`.