### PR TITLE
Run "git log" under the same user that cloned the repo

### DIFF
--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -15,77 +15,82 @@
     group: "{{ netbox_group }}"
     state: directory
 
-- name: Check existence of commit 1fb67b7, fixing issue netbox#2239
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^1fb67b791f1a91c624dae4a1cd256e4cf3ddbb77'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_issue_2239_fix
-  changed_when: false
-  failed_when: "_netbox_git_contains_issue_2239_fix.rc not in [0, 1]"
+- name: Check for presence of various commits in git history
+  block:
+    - name: Check existence of commit 1fb67b7, fixing issue netbox#2239
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^1fb67b791f1a91c624dae4a1cd256e4cf3ddbb77'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_issue_2239_fix
+      changed_when: false
+      failed_when: "_netbox_git_contains_issue_2239_fix.rc not in [0, 1]"
 
-- name: Check existence of commit 3590ed3, renaming webhooks to tasks
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^3590ed378d161dd724fad2dc73ff56da746352f8'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_tasks_rename
-  changed_when: false
-  failed_when: "_netbox_git_contains_tasks_rename.rc not in [0, 1]"
+    - name: Check existence of commit 3590ed3, renaming webhooks to tasks
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^3590ed378d161dd724fad2dc73ff56da746352f8'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_tasks_rename
+      changed_when: false
+      failed_when: "_netbox_git_contains_tasks_rename.rc not in [0, 1]"
 
-- name: Check existence of commit 90dbe9b, renaming DEFAULT_TIMEOUT to RQ_DEFAULT_TIMEOUT
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^90dbe9bf60ab3c72be10fd070c65c26dca543ca5'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_rq_timeout
-  changed_when: False
-  failed_when: "_netbox_git_contains_rq_timeout.rc not in [0, 1]"
+    - name: Check existence of commit 90dbe9b, renaming DEFAULT_TIMEOUT to RQ_DEFAULT_TIMEOUT
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^90dbe9bf60ab3c72be10fd070c65c26dca543ca5'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_rq_timeout
+      changed_when: False
+      failed_when: "_netbox_git_contains_rq_timeout.rc not in [0, 1]"
 
-- name: Check existence of commit f560693, introducing trace_paths management command
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^f560693748d1f35e79ad9d006a8a9b75ef5ae37b'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_trace_paths
-  changed_when: False
-  failed_when: "_netbox_git_contains_trace_paths.rc not in [0, 1]"
+    - name: Check existence of commit f560693, introducing trace_paths management command
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^f560693748d1f35e79ad9d006a8a9b75ef5ae37b'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_trace_paths
+      changed_when: False
+      failed_when: "_netbox_git_contains_trace_paths.rc not in [0, 1]"
 
-- name: Check existence of commit e165dca, introducing mkdocs command during update
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^7058d6ca5ae2901383874bcea5fedad31e165dca'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_mkdocs
-  changed_when: False
-  failed_when: "_netbox_git_contains_mkdocs.rc not in [0, 1]"
+    - name: Check existence of commit e165dca, introducing mkdocs command during update
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^7058d6ca5ae2901383874bcea5fedad31e165dca'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_mkdocs
+      changed_when: False
+      failed_when: "_netbox_git_contains_mkdocs.rc not in [0, 1]"
 
-- name: Check existence of commit d87ec82, introducing nightly housekeeping command
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^d87ec82fe34d92a84ee6f2a97ba0a87a53eed015'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_housekeeping
-  changed_when: False
-  failed_when: "_netbox_git_contains_housekeeping.rc not in [0, 1]"
+    - name: Check existence of commit d87ec82, introducing nightly housekeeping command
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^d87ec82fe34d92a84ee6f2a97ba0a87a53eed015'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_housekeeping
+      changed_when: False
+      failed_when: "_netbox_git_contains_housekeeping.rc not in [0, 1]"
 
-- name: Check existence of commit 028c876, removing the invalidate command
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^028c876bcafbaede2731f191512bbebe3f1b6a9e'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_invalidate_removed
-  changed_when: False
-  failed_when: "_netbox_git_contains_invalidate_removed.rc not in [0, 1]"
+    - name: Check existence of commit 028c876, removing the invalidate command
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^028c876bcafbaede2731f191512bbebe3f1b6a9e'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_invalidate_removed
+      changed_when: False
+      failed_when: "_netbox_git_contains_invalidate_removed.rc not in [0, 1]"
 
-- name: Check existence of commit b172ae6, adding the clearcache command
-  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^b172ae65d24f6dc161c4b609477a4547bb62a50b'
-  args:
-    chdir: "{{ netbox_git_repo_path }}"
-    executable: /bin/bash
-  register: _netbox_git_contains_add_clearcache
-  changed_when: False
-  failed_when: "_netbox_git_contains_add_clearcache.rc not in [0, 1]"
+    - name: Check existence of commit b172ae6, adding the clearcache command
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^b172ae65d24f6dc161c4b609477a4547bb62a50b'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_add_clearcache
+      changed_when: False
+      failed_when: "_netbox_git_contains_add_clearcache.rc not in [0, 1]"
+
+  become: true
+  become_user: "{{ netbox_user }}"
 
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'


### PR DESCRIPTION
This avoids "fatal: detected dubious ownership in repository" errors that cause all feature-detection commands to fail.

Fixes #164 