### PR TITLE
Compatibility with Netbox 3.7

### DIFF
--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -204,7 +204,7 @@
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
 
-    - name: Clear cached data in NetBox
+    - name: Clear cached data in NetBox < 3
       django_manage:
         command: "invalidate all"
         app_path: "{{ netbox_current_path }}/netbox"
@@ -213,14 +213,16 @@
         - netbox_stable and netbox_stable_version is version('3.0.0', '<')
           or netbox_git and _netbox_git_contains_invalidate_removed.rc != 0
 
-    - name: Clear cached data in NetBox 3.2.3+
+    - name: Clear cached data in NetBox 3.2.3 to 3.6
       django_manage:
         command: "clearcache"
         app_path: "{{ netbox_current_path }}/netbox"
         virtualenv: "{{ netbox_virtualenv_path }}"
       when:
         - netbox_stable and netbox_stable_version is version('3.2.2', '>')
-          or netbox_git and _netbox_git_contains_add_clearcache.rc == 0
+          and netbox_stable_version is version('3.7.0', '<')
+          or netbox_git and _netbox_git_contains_add_clearcache.rc == 0 
+          and _netbox_git_contains_remove_clearcache != 0
 
   become: true
   become_user: "{{ netbox_user }}"

--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -87,6 +87,15 @@
   changed_when: False
   failed_when: "_netbox_git_contains_add_clearcache.rc not in [0, 1]"
 
+- name: Check existence of commit 2d1f882, removing the clearcache command
+  shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^2d1f88272497ca72d2e1eca8e291c04538c6810e'
+  args:
+    chdir: "{{ netbox_git_repo_path }}"
+    executable: /bin/bash
+  register: _netbox_git_contains_remove_clearcache
+  changed_when: False
+  failed_when: "_netbox_git_contains_remove_clearcache.rc not in [0, 1]"
+
 - name: Archive and extract snapshot of git repository
   shell: 'set -o pipefail; git archive "{{ netbox_git_version }}" | tar -x -C "{{ netbox_git_deploy_path }}"'
   args:


### PR DESCRIPTION
https://github.com/netbox-community/netbox/commit/2d1f88272497ca72d2e1eca8e291c04538c6810e removed the 'clearcache' command, so this needs to be skipped for release 3.7.0 and later.