### PR TITLE
User get_user_model() rather than importing User directly

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,8 +14,9 @@ _netbox_storages_map:
   sftpstorage: []
 
 netbox_superuser_script: |
-  from django.contrib.auth.models import User
+  from django.contrib.auth import get_user_model
   from base64 import b64decode
+  User = get_user_model()
   password = b64decode("{{ netbox_superuser_password | b64encode }}").decode("UTF-8")
   query = User.objects.filter(username="{{ netbox_superuser_username }}")
   if not query.exists():
@@ -33,7 +34,8 @@ netbox_superuser_script: |
 
 netbox_superuser_token: |
     from users.models import Token
-    from django.contrib.auth.models import User
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
     user = User.objects.get(username="{{ netbox_superuser_username }}")
     query = Token.objects.filter(user=user)
     if not query.exists():


### PR DESCRIPTION
This is the recommended way to reference the user model according to the documentation[1].  It should be supported by at least Django 4, so can be assumed to work for NetBox releases older than 4.0 as well.  I have only tested it with 4.0(.1) though.

[1] https://docs.djangoproject.com/en/5.0/topics/auth/customizing/#referencing-the-user-model

Closes #179