### PR TITLE
Support for local_settings.py settings override file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -401,6 +401,19 @@ role. If this is undesirable, consider toggling `netbox_superuser_enabled`.
 
 [source,yaml]
 ----
+netbox_local_settings_enabled: false
+netbox_local_settings_config_file: local_setting.py
+----
+
+Toggle `netbox_local_settings_enabled` to `true` to deploy local_settings.py for
+NetBox. `netbox_local_settings_config_file` should be the path to your file - by
+default, Ansible will search your playbook's `files/` directory for this.
+
+NOTE: The destination file will always be `local_settings.py`, the source file name
+can be unique.
+
+[source,yaml]
+----
 netbox_napalm_enabled: false
 netbox_napalm_packages:
   - napalm

--- a/README.adoc
+++ b/README.adoc
@@ -404,9 +404,10 @@ role. If this is undesirable, consider toggling `netbox_superuser_enabled`.
 netbox_local_settings_file: netbox_local_settings.py
 ----
 
-Add the file to copy from ansible to `netbox_local_settings_file` to deploy local_settings.py to 
-NetBox. `netbox_local_settings_file` should be the path to your file - by
-default, Ansible will search your playbook's `files/` directory for this.
+Add the `netbox_local_settings_file` var with the name of the local settings 
+file in your ansible repository to deploy local_settings.py to NetBox. 
+Ansible will search your playbook's `files/` directory for this when using a 
+relative path.
 
 NOTE: The destination file will always be `local_settings.py`, the source file name
 can be unique to allow for different deployments from the one ansible repository.

--- a/README.adoc
+++ b/README.adoc
@@ -401,16 +401,15 @@ role. If this is undesirable, consider toggling `netbox_superuser_enabled`.
 
 [source,yaml]
 ----
-netbox_local_settings_enabled: false
-netbox_local_settings_config_file: local_setting.py
+netbox_local_settings_file: netbox_local_settings.py
 ----
 
-Toggle `netbox_local_settings_enabled` to `true` to deploy local_settings.py for
-NetBox. `netbox_local_settings_config_file` should be the path to your file - by
+Add the file to copy from ansible to `netbox_local_settings_file` to deploy local_settings.py to 
+NetBox. `netbox_local_settings_file` should be the path to your file - by
 default, Ansible will search your playbook's `files/` directory for this.
 
 NOTE: The destination file will always be `local_settings.py`, the source file name
-can be unique.
+can be unique to allow for different deployments from the one ansible repository.
 
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -401,16 +401,16 @@ role. If this is undesirable, consider toggling `netbox_superuser_enabled`.
 
 [source,yaml]
 ----
-netbox_local_settings_file: netbox_local_settings.py
+# netbox_local_settings_file: "{{ playbook_dir }}/files/netbox/local_settings.py"
 ----
 
-Add the `netbox_local_settings_file` var with the name of the local settings 
-file in your ansible repository to deploy local_settings.py to NetBox. 
-Ansible will search your playbook's `files/` directory for this when using a 
-relative path.
+If you need to override any settings or extend the functionality in NetBox' `settings.py`
+in a way that is not supported by the `configuration.py` (i.e. the `netbox_config` role variable),
+you can set `netbox_local_settings_file` to a local file path in your playbook to deploy a `local_settings.py` file within NetBox.
+This feature was https://github.com/netbox-community/netbox/issues/16127[introduced in NetBox v4.0.2].
+You may need to use this file for deploying certain NetBox plugins.
 
-NOTE: The destination file will always be `local_settings.py`, the source file name
-can be unique to allow for different deployments from the one ansible repository.
+NOTE: Commenting or removing this role variable from your playbook will remove `local_settings.py` from your NetBox deployment.
 
 [source,yaml]
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,8 +74,7 @@ netbox_requests_log: "file:{{ netbox_shared_path }}/requests.log"
 netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 
-netbox_local_settings_enabled: false
-netbox_local_settings_config_file: "netbox_local_settings.py"
+netbox_local_settings_file:
 
 netbox_napalm_enabled: false
 netbox_napalm_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ netbox_requests_log: "file:{{ netbox_shared_path }}/requests.log"
 netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 
-netbox_local_settings_file:
+# netbox_local_settings_file: "{{ playbook_dir }}/files/netbox/local_settings.py"
 
 netbox_napalm_enabled: false
 netbox_napalm_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,9 @@ netbox_requests_log: "file:{{ netbox_shared_path }}/requests.log"
 netbox_ldap_enabled: false
 netbox_ldap_config_template: netbox_ldap_config.py.j2
 
+netbox_local_settings_enabled: false
+netbox_local_settings_config_file: "netbox_local_settings.py"
+
 netbox_napalm_enabled: false
 netbox_napalm_packages:
   - napalm

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -133,6 +133,30 @@
   notify:
     - reload netbox.service
 
+# local_settings.py
+- name: Copy NetBox local_settings.py into shared (ignore if it doesn't exist)
+  copy:
+    src: "{{ playbook_dir }}/files/netbox/local_settings.py"
+    dest: "{{ netbox_shared_path }}/local_settings.py"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_group }}"
+  ignore_errors: yes
+
+- name: Check if local_settings.py file exists in shared
+  stat:
+    path: "{{ netbox_shared_path }}/local_settings.py"
+  register: netbox_local_settings_file_in_shared
+
+- name: Symlink/Remove NetBox local_settings.py file into/from the active NetBox release
+  file:
+    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_file_in_shared.stat.exists else omit }}"
+    dest: "{{ netbox_config_path }}/local_settings.py"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_group }}"
+    state: "{{ 'link' if netbox_local_settings_file_in_shared.stat.exists else 'absent' }}"
+  notify:
+    - reload netbox.service
+
 - name: Copy NetBox scripts into SCRIPTS_ROOT
   copy:
     src: "{{ item.src }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -136,23 +136,23 @@
 # local_settings.py
 - name: Copy NetBox local_settings.py into shared (ignore if it doesn't exist)
   ansible.builtin.copy:
-    src: "{{ netbox_local_settings_config_file }}"
+    src: "{{ netbox_local_settings_file }}"
     dest: "{{ netbox_shared_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
   ignore_errors: yes
   when:
-    - netbox_local_settings_enabled
+    - netbox_local_settings_file is defined
   notify:
     - reload netbox.service
 
 - name: Symlink/Remove NetBox local_settings.py file into/from the active NetBox release
   file:
-    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_enabled else omit }}"
+    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_file is defined else omit }}"
     dest: "{{ netbox_config_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
-    state: "{{ 'link' if netbox_local_settings_enabled else 'absent' }}"
+    state: "{{ 'link' if netbox_local_settings_file is defined else 'absent' }}"
   notify:
     - reload netbox.service
 

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -135,25 +135,24 @@
 
 # local_settings.py
 - name: Copy NetBox local_settings.py into shared (ignore if it doesn't exist)
-  copy:
-    src: "{{ playbook_dir }}/files/netbox/local_settings.py"
+  ansible.builtin.copy:
+    src: "{{ netbox_local_settings_config_file }}"
     dest: "{{ netbox_shared_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
   ignore_errors: yes
-
-- name: Check if local_settings.py file exists in shared
-  stat:
-    path: "{{ netbox_shared_path }}/local_settings.py"
-  register: netbox_local_settings_file_in_shared
+  when:
+    - netbox_local_settings_enabled
+  notify:
+    - reload netbox.service
 
 - name: Symlink/Remove NetBox local_settings.py file into/from the active NetBox release
   file:
-    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_file_in_shared.stat.exists else omit }}"
+    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_enabled else omit }}"
     dest: "{{ netbox_config_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
-    state: "{{ 'link' if netbox_local_settings_file_in_shared.stat.exists else 'absent' }}"
+    state: "{{ 'link' if netbox_local_settings_enabled else 'absent' }}"
   notify:
     - reload netbox.service
 

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -140,15 +140,14 @@
     dest: "{{ netbox_shared_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
-  ignore_errors: yes
   when:
     - netbox_local_settings_file is defined
   notify:
     - reload netbox.service
 
 - name: Symlink/Remove NetBox local_settings.py file into/from the active NetBox release
-  file:
-    src: "{{ netbox_shared_path + '/local_settings.py' if netbox_local_settings_file is defined else omit }}"
+  ansible.builtin.file:
+    src: "{{ netbox_shared_path }}/local_settings.py"
     dest: "{{ netbox_config_path }}/local_settings.py"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"


### PR DESCRIPTION
This PR configures local_settings.py.

This is required for the deployment of the branch plugin as this file must exist before the migrations are run if the plugin is enabled. You can't otherwise use this role if you want the branch plugin.

- The role now automatically tries to copy from `{{ playbook_dir }}/files/netbox/local_settings.py`, files/netbox as local_settings.py is a generic name that could be used by other plays or roles.
- Errors are ignored on the copy in place of testing if the files exists or a var being set
- The symlink creation tests for the existence of local_settings.py in the shared director. If a user add's local_settings.py to the shared directory manually the role will still use it.
- The role doesn't have a way to remove the local_settings.py from the shared directory, if the user wants to remove the local_settings.py they can remove it from shared.