### PR TITLE
Don't run Amplify on PRs from forks

### DIFF
--- a/.github/workflows/amplify.yml
+++ b/.github/workflows/amplify.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   workflow_dispatch: {}
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ jobs:
   amplify-security-scan:
     name: Amplify Security Scan
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub does not mint OIDC tokens for externally sourced PRs so this workflow can't successfully run. An alternative solution (like via an approval comment?) should be identified and implemented eventually to allow the workflow for previous contributors using their own forks.
