### PR TITLE
Use pull_request_target for Amplify workflow

### DIFF
--- a/.github/workflows/amplify.yml
+++ b/.github/workflows/amplify.yml
@@ -1,7 +1,7 @@
 ---
 name: Amplify Security
 on:
-  pull_request: {}
+  pull_request_target: {}
   workflow_dispatch: {}
   push:
     branches: ["main", "develop"]
@@ -11,12 +11,23 @@ permissions:
   id-token: write
 
 jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   amplify-security-scan:
     name: Amplify Security Scan
+    needs: authorize
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Amplify Runner
-        uses: amplify-security/runner-action@v0.1.0
+        uses: amplify-security/runner-action@926f003f3c9695a93cbc4e2f1e64eb784dcacbfc  # v0.2.0


### PR DESCRIPTION
set environment to "external for forks, which is configured to require approval in the repository settings
