### PR TITLE
Alternative socket use

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -155,10 +155,16 @@ netbox_database_user: netbox
 #netbox_database_host: localhost
 netbox_database_port: 5432
 #netbox_database_socket: /var/run/postgresql
+#netbox_database_alt_socket: false
 ----
 
 It is *required* to configure either a socket directory (to communicate over UNIX sockets) or a host/password (to use TCP/IP).
 See the _Example Playbook_ section for more information on configuring the database.
+
+Setting `netbox_database_alt_socket` to `true` will skip the database connectivity check
+tasks and also set `netbox_database_port` alongside the socket connection for the
+database configuration. This will help with environments that may be running pgbouncer
+on the same server as NetBox.
 
 Note that these are used to configure `DATABASE` in `configuration.py`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ netbox_database_user: netbox
 # netbox_database_host: localhost
 netbox_database_port: 5432
 # netbox_database_socket: /var/run/postgresql
+netbox_database_alt_socket: false
 netbox_database_conn_age: 0
 netbox_database_options: {}
 netbox_database_maintenance: "postgres"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
   when:
     - netbox_database_socket is defined
     - netbox_database_host is not defined
+    - not netbox_database_alt_socket
 
 - name: Ensure Postgres database exists (via TCP)
   community.postgresql.postgresql_db:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -25,6 +25,9 @@ DATABASE = {
 {%      if netbox_database_password is defined %}
     'PASSWORD': '{{ netbox_database_password }}',
 {%      endif %}
+{% if netbox_database_alt_socket and netbox_database_socket is defined %}
+    'PORT': '{{ netbox_database_port }}',
+{% endif %}
     'HOST': '{{ netbox_database_socket }}',
 {% endif %}
     'CONN_MAX_AGE': {{ netbox_database_conn_age }},


### PR DESCRIPTION
Fixes https://github.com/lae/ansible-role-netbox/issues/185

I opted for setting `netbox_database_alt_socket` to skip the database connectivity check tasks altogether as making them fit my pgbouncer setup would require even more changes to the task.