### PR TITLE
Add support for custom pip extra args

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -327,6 +327,17 @@ Read https://netbox.readthedocs.io/en/stable/plugins/[Plugins] for more info.
 
 [source,yaml]
 ----
+netbox_pip_extra_args: []
+----
+
+This variable controls the pip installation behavior:
+
+- `netbox_pip_extra_args`: List of additional arguments passed to all `pip` commands in NetBox's virtualenv (e.g., `['-i', 'https://pypi.example.com/simple', '--trusted-host', 'pypi.example.com']`)
+
+Note: Constraint files (`-c constraints.txt`) are automatically included for all pip operations in the NetBox virtualenv.
+
+[source,yaml]
+----
 netbox_user: netbox
 netbox_group: netbox
 netbox_home: /srv/netbox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,7 @@ netbox_napalm_enabled: false
 netbox_napalm_packages:
   - napalm
 
+netbox_skip_pip_cache: false  # If true, use '--no-cache-dir' for pip installs in NetBox venv
 netbox_pip_packages: []
 netbox_pip_constraints:
   # Blacklist pynacl 1.3.0 due to https://github.com/pyca/pynacl/issues/479

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,7 +81,7 @@ netbox_napalm_enabled: false
 netbox_napalm_packages:
   - napalm
 
-netbox_skip_pip_cache: false  # If true, use '--no-cache-dir' for pip installs in NetBox venv
+netbox_pip_extra_args: []  # Additional pip arguments (e.g., ['--no-cache-dir', '-i', 'https://pypi.example.com/simple'])
 netbox_pip_packages: []
 netbox_pip_constraints:
   # Blacklist pynacl 1.3.0 due to https://github.com/pyca/pynacl/issues/479

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -62,7 +62,7 @@
 - name: Install needed Python dependencies
   ansible.builtin.pip:
     requirements: "{{ netbox_shared_path }}/requirements.txt"
-    extra_args: "-c {{ netbox_shared_path }}/constraints.txt"
+    extra_args: "{{ (['-c {{ netbox_shared_path }}/constraints.txt'] + (['--no-cache-dir'] if netbox_skip_pip_cache else [])) | join(' ') }}"
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: true
   become_user: "{{ netbox_user }}"
@@ -75,6 +75,7 @@
     name: "{{ item }}"
     state: present
     virtualenv: "{{ netbox_virtualenv_path }}"
+    extra_args: "{{ '--no-cache-dir' if netbox_skip_pip_cache else omit }}"
   become: true
   become_user: "{{ netbox_user }}"
   retries: 2
@@ -92,7 +93,7 @@
     content: |
       {% for dep in _netbox_python_deps %}
       {{ dep }}
-      {% endfor %}  
+      {% endfor %}
     dest: "{{ netbox_current_path }}/local_requirements.txt"
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -21,7 +21,7 @@
     - _netbox_config.SECRET_KEY is not defined
 
 - name: Create NetBox virtualenv
-  pip:
+  ansible.builtin.pip:
     name:
       - pip
       - setuptools
@@ -62,7 +62,10 @@
 - name: Install needed Python dependencies
   ansible.builtin.pip:
     requirements: "{{ netbox_shared_path }}/requirements.txt"
-    extra_args: "{{ (['-c {{ netbox_shared_path }}/constraints.txt'] + (['--no-cache-dir'] if netbox_skip_pip_cache else [])) | join(' ') }}"
+    extra_args: >-
+      {{ ['-c', netbox_shared_path + '/constraints.txt']
+         + (netbox_pip_extra_args | default([]))
+         | join(' ') }}
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: true
   become_user: "{{ netbox_user }}"
@@ -75,7 +78,10 @@
     name: "{{ item }}"
     state: present
     virtualenv: "{{ netbox_virtualenv_path }}"
-    extra_args: "{{ '--no-cache-dir' if netbox_skip_pip_cache else omit }}"
+    extra_args: >-
+      {{ ['-c', netbox_shared_path + '/constraints.txt']
+         + (netbox_pip_extra_args | default([]))
+         | join(' ') }}
   become: true
   become_user: "{{ netbox_user }}"
   retries: 2

--- a/tasks/deploy_netbox.yml
+++ b/tasks/deploy_netbox.yml
@@ -63,8 +63,8 @@
   ansible.builtin.pip:
     requirements: "{{ netbox_shared_path }}/requirements.txt"
     extra_args: >-
-      {{ ['-c', netbox_shared_path + '/constraints.txt']
-         + (netbox_pip_extra_args | default([]))
+      {{ (['-c', netbox_shared_path + '/constraints.txt']
+         + (netbox_pip_extra_args | default([])))
          | join(' ') }}
     virtualenv: "{{ netbox_virtualenv_path }}"
   become: true
@@ -79,8 +79,8 @@
     state: present
     virtualenv: "{{ netbox_virtualenv_path }}"
     extra_args: >-
-      {{ ['-c', netbox_shared_path + '/constraints.txt']
-         + (netbox_pip_extra_args | default([]))
+      {{ (['-c', netbox_shared_path + '/constraints.txt']
+         + (netbox_pip_extra_args | default([])))
          | join(' ') }}
   become: true
   become_user: "{{ netbox_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,9 @@
     state: "{{ 'latest' if netbox_keep_uwsgi_updated else 'present' }}"
     umask: "0022"
     virtualenv: "{{ omit if not netbox_uwsgi_in_venv else netbox_virtualenv_path }}"
+    extra_args: >-
+      {{ netbox_pip_extra_args | default([])
+         | join(' ') }}
   environment:
     PATH: "/usr/local/bin:{{ _path }}"
   notify:


### PR DESCRIPTION
This PR adds support for customizing pip arguments - most notably, custom `index-url` commands for users that have internal PyPi mirrors/proxies to the steps that use the `pip` module.