### PR TITLE
Fix redis vars on example playbook for single host deploy

### DIFF
--- a/examples/playbook_single_host_deploy.yml
+++ b/examples/playbook_single_host_deploy.yml
@@ -25,6 +25,7 @@
         role_attr_flags: CREATEDB,NOSUPERUSER
     redis_bind: 127.0.0.1
     redis_version: 6.0.9
+    redis_download_url: "https://download.redis.io/releases/redis-{{ redis_version }}.tar.gz"
     redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
   pre_tasks:
     - name: Enable Subscription Manager Repos

--- a/examples/playbook_single_host_deploy.yml
+++ b/examples/playbook_single_host_deploy.yml
@@ -24,7 +24,7 @@
       - name: "{{ netbox_database_user }}"
         role_attr_flags: CREATEDB,NOSUPERUSER
     redis_bind: 127.0.0.1
-    redis_version: 6.0.9
+    redis_version: 6.2.14
     redis_download_url: "https://download.redis.io/releases/redis-{{ redis_version }}.tar.gz"
     redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
   pre_tasks:

--- a/examples/playbook_single_host_deploy.yml
+++ b/examples/playbook_single_host_deploy.yml
@@ -26,7 +26,7 @@
     redis_bind: 127.0.0.1
     redis_version: 6.2.14
     redis_download_url: "https://download.redis.io/releases/redis-{{ redis_version }}.tar.gz"
-    redis_checksum: sha256:dc2bdcf81c620e9f09cfd12e85d3bc631c897b2db7a55218fd8a65eaa37f86dd
+    redis_checksum: sha256:34e74856cbd66fdb3a684fb349d93961d8c7aa668b06f81fd93ff267d09bc277
   pre_tasks:
     - name: Enable Subscription Manager Repos
       rhsm_repository:


### PR DESCRIPTION
by merging this request, we:

  * set the proper `redis_download_url`, directly defining it to use HTTPS;
  * update `redis_version` to follow the latest stable v6 release (6.2.14);
  * correct the `redis_checksum` to match the release tarball.

> this change respects the upstream role from @DavidWittman, though keeps using redis v6 for minimum impacts.

here's an output of how the previous URL was not working, and this it's fine after the update:
- before
```sh
$ curl -s -o before https://download.redis.io/redis-6.2.14.tar.gz
$ file before
before: HTML document, ASCII text, with CRLF line terminators
$ sha256sum before 
340c8464c2007ce3f80682e15dfafa4180b641d53c14201b929906b7b0284d87  before
$ cat before 
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```
- after
```sh
$ curl -s -o after https://download.redis.io/releases/redis-6.2.14.tar.gz
$ file after 
after: gzip compressed data, was "redis-6.2.14.tar", last modified: Wed Oct 18 07:56:35 2023, max compression, from Unix, original size modulo 2^32 11284480
$ sha256sum after 
34e74856cbd66fdb3a684fb349d93961d8c7aa668b06f81fd93ff267d09bc277  after
```