### PR TITLE
Add Ubuntu 24 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ Deploys and configures https://github.com/netbox-community/netbox[NetBox], an IP
 
 This role will deploy NetBox within its own virtualenv either by release tarball or via git using uWSGI as the application server.
 
-Supports CentOS 7, 8 / RHEL 9 / Debian 9, 10, 11, 12, 13 / Ubuntu 16, 18, 20 and 22.
+Supports CentOS 7, 8 / RHEL 9 / Debian 9, 10, 11, 12, 13 / Ubuntu 16, 18, 20 22 and 24.
 
 Note that this role is slightly opinionated and differs from installation instructions from the NetBox documentation.
 The main differences are:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
         - xenial
         - focal
         - jammy
+        - noble
     - name: Debian
       versions:
         - buster

--- a/vars/ubuntu-24.yml
+++ b/vars/ubuntu-24.yml
@@ -1,0 +1,19 @@
+---
+_netbox_packages:
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libjpeg-dev
+  - graphviz
+  - libpq-dev
+  - libssl-dev
+_netbox_python_packages:
+  - python3
+  - python3-dev
+  - python3-pip
+  - python3-venv
+  - python3-psycopg2 # used by ansible's postgres modules
+_netbox_python_binary: /usr/bin/python3
+_netbox_ldap_packages:
+  - libldap2-dev
+  - libsasl2-dev


### PR DESCRIPTION
Similar to the recent Debian Trixie and previous Ubuntu 22.04 support, this is simply a copy of the ubuntu-22 into ubuntu-24 and it seems to work.

Tested with netbox_stable_version: 4.4.5. The default (3.0.12) does not work with the latest version of pyYaml.