### PR TITLE
Add support for new 'DATABASES' configuration keyword since Netbox 4.3

### DIFF
--- a/tasks/install_via_git.yml
+++ b/tasks/install_via_git.yml
@@ -107,6 +107,15 @@
       changed_when: False
       failed_when: "_netbox_git_contains_reindex_lazy.rc not in [0, 1]"
 
+    - name: Check existence of commit d4f8cb7, renaming DATABASE to DATABASES
+      shell: 'set -o pipefail; git log --format=%H "{{ netbox_git_version }}" | grep ^d4f8cb72aa6ef010b3746c29973ecf276f392bf9'
+      args:
+        chdir: "{{ netbox_git_repo_path }}"
+        executable: /bin/bash
+      register: _netbox_git_contains_database_rename
+      changed_when: False
+      failed_when: "_netbox_git_contains_database_rename.rc not in [0, 1]"
+
   become: true
   become_user: "{{ netbox_user }}"
 

--- a/templates/configuration.d/databases.j2
+++ b/templates/configuration.d/databases.j2
@@ -1,0 +1,25 @@
+    'NAME': '{{ netbox_database }}',
+    'USER': '{{ netbox_database_user }}',
+{% if netbox_database_host is defined %}
+    'PASSWORD': '{{ netbox_database_password }}',
+    'HOST':  '{{ netbox_database_host }}',
+    'PORT': '{{ netbox_database_port }}',
+{% else %}
+{%      if netbox_database_password is defined %}
+    'PASSWORD': '{{ netbox_database_password }}',
+{%      endif %}
+{%      if netbox_database_alt_socket and netbox_database_socket is defined %}
+    'PORT': '{{ netbox_database_port }}',
+{%      endif %}
+    'HOST': '{{ netbox_database_socket }}',
+{% endif %}
+    'CONN_MAX_AGE': {{ netbox_database_conn_age }},
+{% if netbox_database_options|length > 0 %}
+    'OPTIONS': {
+        {% for setting, value in netbox_database_options.items() %}
+        {% if value is string or value is number %}
+        "{{ setting }}": {{ value | to_nice_json }},
+        {% endif %}
+        {% endfor %}
+    },
+{% endif %}

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -17,39 +17,15 @@ if "prometheus_multiproc_dir" in os.environ:
 {% if netbox_stable and netbox_stable_version is version('4.3', '>=') or
       netbox_git and _netbox_git_contains_database_rename.rc == 0 %}
 DATABASES = {
-'default': {
-    'ENGINE': 'django.db.backends.postgresql',
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+{% filter indent(first=true) %}
+{% include 'configuration.d/databases.j2' %}
+{% endfilter %}
+    }
 {% else %}
 DATABASE = {
-{% endif %}
-    'NAME': '{{ netbox_database }}',
-    'USER': '{{ netbox_database_user }}',
-{% if netbox_database_host is defined %}
-    'PASSWORD': '{{ netbox_database_password }}',
-    'HOST':  '{{ netbox_database_host }}',
-    'PORT': '{{ netbox_database_port }}',
-{% else %}
-{%      if netbox_database_password is defined %}
-    'PASSWORD': '{{ netbox_database_password }}',
-{%      endif %}
-{% if netbox_database_alt_socket and netbox_database_socket is defined %}
-    'PORT': '{{ netbox_database_port }}',
-{% endif %}
-    'HOST': '{{ netbox_database_socket }}',
-{% endif %}
-    'CONN_MAX_AGE': {{ netbox_database_conn_age }},
-{% if netbox_database_options|length > 0 %}
-    'OPTIONS': {
-        {% for setting, value in netbox_database_options.items() %}
-        {% if value is string or value is number %}
-        "{{ setting }}": {{ value | to_nice_json }},
-        {% endif %}
-        {% endfor %}
-    },
-{% endif %}
-{% if netbox_stable and netbox_stable_version is version('4.3', '>=') or
-      netbox_git and _netbox_git_contains_database_rename.rc == 0 %}
-    }
+{% include 'configuration.d/databases.j2' %}
 {% endif %}
 }
 

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -14,7 +14,14 @@ if "prometheus_multiproc_dir" in os.environ:
         pass  # not running in uwsgi
 {% endif %}
 
+{% if netbox_stable and netbox_stable_version is version('4.3', '>=') or
+      netbox_git and _netbox_git_contains_database_rename.rc == 0 %}
+DATABASES = {
+'default': {
+    'ENGINE': 'django.db.backends.postgresql',
+{% else %}
 DATABASE = {
+{% endif %}
     'NAME': '{{ netbox_database }}',
     'USER': '{{ netbox_database_user }}',
 {% if netbox_database_host is defined %}
@@ -39,6 +46,10 @@ DATABASE = {
         {% endif %}
         {% endfor %}
     },
+{% endif %}
+{% if netbox_stable and netbox_stable_version is version('4.3', '>=') or
+      netbox_git and _netbox_git_contains_database_rename.rc == 0 %}
+    }
 {% endif %}
 }
 


### PR DESCRIPTION
This supersedes the 'DATABASE' keyword, which is still supported but marked as deprecated. Noticed this when I tried to install a plugin on a relatively recent version of Netbox (4.5.2).

I'm not really happy with indentation in `configuration.py` yet.
* Syntax < 4.3:
   ```
   DATABASE = {
       'NAME': 'netbox',
       'USER': 'netbox',
       'HOST': '/var/run/postgresql',
       'CONN_MAX_AGE': 0,
   }
   ```
* Syntax >= 4.3:
   ```
   DATABASES = {
   'default': {
       'ENGINE': 'django.db.backends.postgresql',
       'NAME': 'netbox',
       'USER': 'netbox',
       'HOST': '/var/run/postgresql',
       'CONN_MAX_AGE': 0,
       }
   }
   ```
The official documentation shows a nicer indentation, but it's hard to template without duplicating the whole `DATABASE` block in the template, suggestions welcome: https://netboxlabs.com/docs/netbox/installation/netbox/#databases